### PR TITLE
phase 5: artifact system

### DIFF
--- a/server/artifact/artifact.go
+++ b/server/artifact/artifact.go
@@ -1,0 +1,64 @@
+// Package artifact provides the artifact resolution system for rig.
+// Before any services start, all artifacts (compiled binaries, pulled Docker
+// images, downloaded files) are resolved in parallel. Results are cached
+// content-addressably so subsequent runs are instant when inputs haven't changed.
+package artifact
+
+import "context"
+
+// Artifact describes a single artifact that must be resolved before services start.
+// Key is a globally unique identifier used for deduplication across a single
+// Orchestrate call — if two services reference the same artifact key, it is
+// resolved only once.
+type Artifact struct {
+	Key      string   // dedup key (e.g. "gobuild:/abs/path/to/module")
+	Resolver Resolver // knows how to build/pull/download
+}
+
+// Output is the result of a successful artifact resolution.
+type Output struct {
+	Path string            // local path to the resolved artifact (binary, download); empty for non-file artifacts (docker images)
+	Meta map[string]string // type-specific metadata (e.g. module name, image digest)
+}
+
+// Resolver knows how to produce an Artifact output.
+type Resolver interface {
+	// CacheKey returns a stable content-based key used to locate the on-disk
+	// cache directory for this artifact. For local builds this is a hash of
+	// the source tree; for network artifacts it is derived from the version pin.
+	CacheKey() (string, error)
+
+	// Cached checks whether a previously resolved artifact exists in outputDir.
+	// Each resolver knows what evidence to look for — a compiled binary, a
+	// breadcrumb file, etc. Returns the reconstructed Output and true on a hit,
+	// or zero value and false on a miss.
+	//
+	// This replaces a generic meta.json cache: the resolver owns both producing
+	// and checking its own artifacts.
+	Cached(outputDir string) (Output, bool)
+
+	// Resolve produces the artifact in outputDir. The caller guarantees that
+	// Resolve is only called after Cached returned false. The resolver writes
+	// whatever it needs into outputDir so that a future Cached call will
+	// find the result.
+	Resolve(ctx context.Context, outputDir string) (Output, error)
+
+	// Retryable reports whether transient errors during Resolve should be
+	// retried. Returns true for network-dependent operations (docker pull,
+	// download), false for local operations (go build, command).
+	Retryable() bool
+}
+
+// Validator is an optional interface for resolvers whose artifacts can
+// disappear externally — Docker images can be pruned, downloaded binaries
+// can be deleted by other tools. When a Resolver also implements Validator,
+// the resolution framework calls Valid after a successful Cached check.
+// If Valid returns false, the cached result is discarded and the artifact
+// is re-resolved.
+//
+// Resolvers whose artifacts live entirely within rig's cache directory
+// (GoBuild, Download) do not need this — those files only disappear if
+// rig itself cleans them up.
+type Validator interface {
+	Valid(output Output) bool
+}

--- a/server/artifact/cache.go
+++ b/server/artifact/cache.go
@@ -1,0 +1,55 @@
+package artifact
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// Cache manages on-disk cache directories and file locks for artifacts.
+// Each cache key maps to a directory under the cache root where resolvers
+// store their output. File locks prevent duplicate work when multiple rigd
+// instances resolve the same artifact concurrently.
+//
+// The Cache itself does not know what's inside each directory — that's the
+// resolver's responsibility via Cached/Resolve.
+type Cache struct {
+	dir string
+}
+
+// NewCache creates a Cache rooted at dir. The directory is created lazily.
+func NewCache(dir string) *Cache {
+	return &Cache{dir: dir}
+}
+
+// OutputDir returns the directory where a resolver should place its output for
+// cacheKey. The directory is created if it does not exist.
+func (c *Cache) OutputDir(cacheKey string) string {
+	dir := filepath.Join(c.dir, cacheKey)
+	os.MkdirAll(dir, 0o755) //nolint:errcheck — best effort; Resolve will fail if dir is needed
+	return dir
+}
+
+// Lock acquires an exclusive file lock for cacheKey, preventing duplicate
+// resolution work across concurrent rigd instances. Returns an unlock function
+// that must be called when the critical section is done.
+func (c *Cache) Lock(cacheKey string) (unlock func(), err error) {
+	if err := os.MkdirAll(c.dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create cache dir: %w", err)
+	}
+	lockPath := filepath.Join(c.dir, cacheKey+".lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("acquire lock: %w", err)
+	}
+	return func() {
+		syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint:errcheck
+		f.Close()
+		os.Remove(lockPath) // best-effort cleanup
+	}, nil
+}

--- a/server/artifact/cache_test.go
+++ b/server/artifact/cache_test.go
@@ -1,0 +1,34 @@
+package artifact_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/matgreaves/rig/server/artifact"
+)
+
+func TestCache_OutputDir(t *testing.T) {
+	dir := t.TempDir()
+	cache := artifact.NewCache(dir)
+
+	outDir := cache.OutputDir("mykey")
+	if outDir == "" {
+		t.Fatal("OutputDir returned empty string")
+	}
+
+	// Directory should exist after OutputDir call.
+	if _, err := os.Stat(outDir); err != nil {
+		t.Errorf("OutputDir %q does not exist: %v", outDir, err)
+	}
+}
+
+func TestCache_Lock(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	unlock, err := cache.Lock("mykey")
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	// Unlock should not panic.
+	unlock()
+}

--- a/server/artifact/gobuild.go
+++ b/server/artifact/gobuild.go
@@ -1,0 +1,226 @@
+package artifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// GoBuild resolves a Go module by compiling it with the local Go toolchain.
+// Module is either an absolute local path ("/abs/path/cmd/server") or a remote
+// module reference ("github.com/myorg/tool@v1.2.3"). Detection: if Module
+// starts with "/" it is local; otherwise remote.
+type GoBuild struct {
+	Module string // absolute local path or remote module reference
+	GOOS   string // defaults to runtime.GOOS
+	GOARCH string // defaults to runtime.GOARCH
+}
+
+func (g GoBuild) goos() string {
+	if g.GOOS != "" {
+		return g.GOOS
+	}
+	return runtime.GOOS
+}
+
+func (g GoBuild) goarch() string {
+	if g.GOARCH != "" {
+		return g.GOARCH
+	}
+	return runtime.GOARCH
+}
+
+func (g GoBuild) isLocal() bool {
+	return strings.HasPrefix(g.Module, "/")
+}
+
+// CacheKey returns a content-based hash suitable for use as a cache directory
+// name. For local modules the hash covers GOOS, GOARCH, and all source file
+// paths and contents. For remote modules the hash covers GOOS, GOARCH, and
+// the module reference (which must include a @version suffix).
+func (g GoBuild) CacheKey() (string, error) {
+	if g.isLocal() {
+		return g.localCacheKey()
+	}
+	return g.remoteCacheKey()
+}
+
+// localCacheKey hashes GOOS, GOARCH, Go version, and all source files.
+//
+// Known limitations:
+//   - go.mod replace directives pointing at local paths: changes in the
+//     replaced module are not reflected in the cache key. Users must clean
+//     the cache manually (or rig cache clean, when available).
+//   - //go:embed files that are not .go/go.mod/go.sum: embedded assets
+//     (templates, SQL migrations, etc.) are not hashed. Same workaround.
+func (g GoBuild) localCacheKey() (string, error) {
+	h := sha256.New()
+	fmt.Fprintf(h, "goos:%s\ngoarch:%s\ngoversion:%s\n", g.goos(), g.goarch(), runtime.Version())
+
+	// Try git ls-files first — fast and excludes build artifacts.
+	files, err := gitSourceFiles(g.Module)
+	if err != nil {
+		// Not a git repo or git not available — fall back to WalkDir.
+		files, err = walkSourceFiles(g.Module)
+		if err != nil {
+			return "", fmt.Errorf("list source files: %w", err)
+		}
+	}
+
+	for _, f := range files {
+		if err := hashFile(h, g.Module, f); err != nil {
+			return "", fmt.Errorf("hash file %s: %w", f, err)
+		}
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (g GoBuild) remoteCacheKey() (string, error) {
+	if !strings.Contains(g.Module, "@") {
+		return "", fmt.Errorf("remote module %q must include a version suffix (e.g. module@v1.2.3)", g.Module)
+	}
+	// The module reference is the version pin; no file hashing needed.
+	raw := fmt.Sprintf("goos:%s\ngoarch:%s\ngoversion:%s\nmodule:%s", g.goos(), g.goarch(), runtime.Version(), g.Module)
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// Cached checks whether a compiled binary exists in outputDir from a previous
+// resolution. GoBuild artifacts live entirely within rig's cache directory,
+// so a simple file existence check is sufficient — no Validator needed.
+func (g GoBuild) Cached(outputDir string) (Output, bool) {
+	p := filepath.Join(outputDir, "binary")
+	info, err := os.Stat(p)
+	if err != nil || info.Size() == 0 {
+		return Output{}, false
+	}
+	return Output{
+		Path: p,
+		Meta: map[string]string{"module": g.Module},
+	}, true
+}
+
+// Resolve compiles the module and places the binary at <outputDir>/binary.
+func (g GoBuild) Resolve(ctx context.Context, outputDir string) (Output, error) {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return Output{}, fmt.Errorf("create output dir: %w", err)
+	}
+
+	outputPath := filepath.Join(outputDir, "binary")
+
+	var cmd *exec.Cmd
+	if g.isLocal() {
+		// Local builds must run from the module directory so go build
+		// resolves against the correct go.mod.
+		cmd = exec.CommandContext(ctx, "go", "build", "-trimpath", "-o", outputPath, ".")
+		cmd.Dir = g.Module
+	} else {
+		cmd = exec.CommandContext(ctx, "go", "build", "-trimpath", "-o", outputPath, g.Module)
+	}
+	cmd.Env = append(os.Environ(),
+		"GOOS="+g.goos(),
+		"GOARCH="+g.goarch(),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		os.Remove(outputPath) // clean up any partial output
+		return Output{}, fmt.Errorf("go build %s: %w\n%s", g.Module, err, string(out))
+	}
+
+	return Output{
+		Path: outputPath,
+		Meta: map[string]string{"module": g.Module},
+	}, nil
+}
+
+// Retryable returns true for remote modules (network operation) and false for
+// local modules (build failures are real failures, not transient).
+func (g GoBuild) Retryable() bool {
+	return !g.isLocal()
+}
+
+// gitSourceFiles returns the absolute paths of all Go source files in dir,
+// including both tracked and untracked (but not ignored) files.
+// Returns an error if dir is not in a git repository or git is not available.
+func gitSourceFiles(dir string) ([]string, error) {
+	filter := []string{"--", "*.go", "go.mod", "go.sum"}
+
+	// Tracked files.
+	trackedCmd := exec.Command("git", append([]string{"-C", dir, "ls-files"}, filter...)...)
+	trackedOut, err := trackedCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files: %w", err)
+	}
+
+	// Untracked, non-ignored files (new files not yet git-added).
+	untrackedCmd := exec.Command("git", append([]string{"-C", dir, "ls-files", "--others", "--exclude-standard"}, filter...)...)
+	untrackedOut, err := untrackedCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files --others: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	var paths []string
+	for _, chunk := range [][]byte{trackedOut, untrackedOut} {
+		for _, line := range strings.Split(strings.TrimSpace(string(chunk)), "\n") {
+			if line == "" {
+				continue
+			}
+			abs := filepath.Join(dir, line)
+			if _, dup := seen[abs]; !dup {
+				seen[abs] = struct{}{}
+				paths = append(paths, abs)
+			}
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// walkSourceFiles returns the absolute paths of all .go, go.mod, and go.sum
+// files found by recursively walking dir. Used as a fallback when git is
+// unavailable or the directory is not in a git repository.
+func walkSourceFiles(dir string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if name == "go.mod" || name == "go.sum" || strings.HasSuffix(name, ".go") {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	return paths, err
+}
+
+// hashFile writes the file's relative path and contents into h.
+// Paths are made relative to baseDir so that cache keys are stable
+// regardless of where the module is checked out on disk.
+func hashFile(h io.Writer, baseDir, path string) error {
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		rel = path // fallback to absolute if Rel fails
+	}
+	fmt.Fprintf(h, "file:%s\n", rel)
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(h, f)
+	return err
+}

--- a/server/artifact/gobuild_test.go
+++ b/server/artifact/gobuild_test.go
@@ -1,0 +1,171 @@
+package artifact_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matgreaves/rig/server/artifact"
+)
+
+// moduleRoot returns the module root by finding go.mod relative to the test
+// working directory. The artifact package is two levels below the module root
+// (server/artifact/).
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Walk up to find go.mod.
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod")
+		}
+		dir = parent
+	}
+}
+
+func TestGoBuild_CacheKey_Stable(t *testing.T) {
+	root := moduleRoot(t)
+	echoDir := filepath.Join(root, "testdata", "services", "echo")
+
+	g := artifact.GoBuild{Module: echoDir}
+
+	key1, err := g.CacheKey()
+	if err != nil {
+		t.Fatalf("CacheKey (first): %v", err)
+	}
+	key2, err := g.CacheKey()
+	if err != nil {
+		t.Fatalf("CacheKey (second): %v", err)
+	}
+
+	if key1 == "" {
+		t.Fatal("CacheKey returned empty string")
+	}
+	if key1 != key2 {
+		t.Errorf("CacheKey not stable: %q != %q", key1, key2)
+	}
+}
+
+func TestGoBuild_CacheKey_Changes(t *testing.T) {
+	// Create a temporary Go module with a single .go file.
+	tmpDir := t.TempDir()
+	modFile := filepath.Join(tmpDir, "go.mod")
+	mainFile := filepath.Join(tmpDir, "main.go")
+
+	if err := os.WriteFile(modFile, []byte("module example.com/tmp\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mainFile, []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	g := artifact.GoBuild{Module: tmpDir}
+	key1, err := g.CacheKey()
+	if err != nil {
+		t.Fatalf("CacheKey before modification: %v", err)
+	}
+
+	// Modify the file.
+	if err := os.WriteFile(mainFile, []byte("package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"changed\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	key2, err := g.CacheKey()
+	if err != nil {
+		t.Fatalf("CacheKey after modification: %v", err)
+	}
+
+	if key1 == key2 {
+		t.Error("CacheKey should change after source modification")
+	}
+}
+
+func TestGoBuild_Resolve(t *testing.T) {
+	root := moduleRoot(t)
+	echoDir := filepath.Join(root, "testdata", "services", "echo")
+
+	g := artifact.GoBuild{Module: echoDir}
+	outputDir := t.TempDir()
+
+	ctx := context.Background()
+	out, err := g.Resolve(ctx, outputDir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if out.Path == "" {
+		t.Fatal("Resolve returned empty Path")
+	}
+
+	// Binary should exist and be executable.
+	info, err := os.Stat(out.Path)
+	if err != nil {
+		t.Fatalf("binary not found at %q: %v", out.Path, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Error("binary is not executable")
+	}
+}
+
+func TestGoBuild_RemoteCacheKey_RequiresVersion(t *testing.T) {
+	g := artifact.GoBuild{Module: "github.com/example/tool"} // no @version
+	_, err := g.CacheKey()
+	if err == nil {
+		t.Error("expected error for remote module without @version")
+	}
+}
+
+func TestGoBuild_Cached(t *testing.T) {
+	g := artifact.GoBuild{Module: "/some/module"}
+	emptyDir := t.TempDir()
+
+	// Empty directory — should be a miss.
+	if _, ok := g.Cached(emptyDir); ok {
+		t.Error("expected cache miss on empty directory")
+	}
+
+	// Write a zero-byte binary — should also be a miss.
+	binaryPath := filepath.Join(emptyDir, "binary")
+	if err := os.WriteFile(binaryPath, []byte{}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := g.Cached(emptyDir); ok {
+		t.Error("expected cache miss for zero-byte binary")
+	}
+
+	// Write a non-empty binary — should be a hit.
+	if err := os.WriteFile(binaryPath, []byte("ELF..."), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, ok := g.Cached(emptyDir)
+	if !ok {
+		t.Fatal("expected cache hit for non-empty binary")
+	}
+	if out.Path != binaryPath {
+		t.Errorf("Path = %q, want %q", out.Path, binaryPath)
+	}
+	if out.Meta["module"] != "/some/module" {
+		t.Errorf("Meta[module] = %q, want %q", out.Meta["module"], "/some/module")
+	}
+}
+
+func TestGoBuild_Retryable(t *testing.T) {
+	local := artifact.GoBuild{Module: "/abs/path"}
+	if local.Retryable() {
+		t.Error("local GoBuild should not be retryable")
+	}
+
+	remote := artifact.GoBuild{Module: "github.com/example/tool@v1.0.0"}
+	if !remote.Retryable() {
+		t.Error("remote GoBuild should be retryable")
+	}
+}

--- a/server/artifact/resolver.go
+++ b/server/artifact/resolver.go
@@ -1,0 +1,211 @@
+package artifact
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// EventKind identifies the type of artifact lifecycle event.
+type EventKind string
+
+const (
+	EventStarted   EventKind = "started"
+	EventCompleted EventKind = "completed"
+	EventCached    EventKind = "cached"
+	EventFailed    EventKind = "failed"
+)
+
+// EmitFunc is called for each artifact lifecycle event.
+// err is non-nil only when kind is EventFailed.
+type EmitFunc func(kind EventKind, key string, err error)
+
+// Resolve resolves all artifacts, deduplicating by Artifact.Key (first wins).
+// Cache-hit artifacts are recorded immediately; cache-miss artifacts are
+// resolved in parallel. Returns a map of Artifact.Key → Output.
+//
+// Retryable resolvers are attempted up to 3 times with exponential backoff
+// (1s, 2s). Non-retryable resolvers are attempted once. The first error from
+// any artifact cancels in-flight resolutions and is returned.
+func Resolve(ctx context.Context, artifacts []Artifact, cache *Cache, emit EmitFunc) (map[string]Output, error) {
+	// Deduplicate by key; first occurrence wins.
+	seen := make(map[string]struct{}, len(artifacts))
+	var unique []Artifact
+	for _, a := range artifacts {
+		if _, exists := seen[a.Key]; !exists {
+			seen[a.Key] = struct{}{}
+			unique = append(unique, a)
+		}
+	}
+
+	results := make(map[string]Output, len(unique))
+	var mu sync.Mutex
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Capacity matches the maximum number of errors that could be sent.
+	errCh := make(chan error, len(unique))
+	var wg sync.WaitGroup
+
+	for _, a := range unique {
+		cacheKey, err := a.Resolver.CacheKey()
+		if err != nil {
+			return nil, fmt.Errorf("artifact %q: cache key: %w", a.Key, err)
+		}
+
+		outputDir := cache.OutputDir(cacheKey)
+
+		// Check cache before spawning a goroutine.
+		if out, ok := checkCached(a.Resolver, outputDir); ok {
+			if emit != nil {
+				emit(EventCached, a.Key, nil)
+			}
+			touchLastUsed(outputDir)
+			mu.Lock()
+			results[a.Key] = out
+			mu.Unlock()
+			continue
+		}
+
+		wg.Add(1)
+		go func(a Artifact, cacheKey, outputDir string) {
+			defer wg.Done()
+
+			// Acquire per-key file lock to prevent duplicate work across
+			// concurrent rigd instances.
+			unlock, err := cache.Lock(cacheKey)
+			if err != nil {
+				errCh <- fmt.Errorf("artifact %q: acquire lock: %w", a.Key, err)
+				return
+			}
+			defer unlock()
+
+			// Re-check cache after acquiring the lock — another process may
+			// have resolved this artifact while we were waiting.
+			if out, ok := checkCached(a.Resolver, outputDir); ok {
+				if emit != nil {
+					emit(EventCached, a.Key, nil)
+				}
+				touchLastUsed(outputDir)
+				mu.Lock()
+				results[a.Key] = out
+				mu.Unlock()
+				return
+			}
+
+			if emit != nil {
+				emit(EventStarted, a.Key, nil)
+			}
+
+			out, resolveErr := resolveWithRetry(ctx, a.Resolver, outputDir)
+			if resolveErr != nil {
+				if emit != nil {
+					emit(EventFailed, a.Key, resolveErr)
+				}
+				cancel()
+				errCh <- fmt.Errorf("artifact %q: %w", a.Key, resolveErr)
+				return
+			}
+
+			if emit != nil {
+				emit(EventCompleted, a.Key, nil)
+			}
+
+			touchLastUsed(outputDir)
+			mu.Lock()
+			results[a.Key] = out
+			mu.Unlock()
+		}(a, cacheKey, outputDir)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	// Return the first real error, preferring non-cancellation errors over
+	// context.Canceled (which are a side-effect of our own cancel() call).
+	var firstErr, firstReal error
+	for err := range errCh {
+		if firstErr == nil {
+			firstErr = err
+		}
+		if firstReal == nil && !errors.Is(err, context.Canceled) {
+			firstReal = err
+		}
+	}
+	if firstReal != nil {
+		return nil, firstReal
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	return results, nil
+}
+
+// checkCached asks the resolver whether a valid cached artifact exists in
+// outputDir. If the resolver also implements Validator (for artifacts whose
+// backing store is outside rig's control, e.g. Docker images), the output
+// is validated against the external source of truth.
+func checkCached(r Resolver, outputDir string) (Output, bool) {
+	out, ok := r.Cached(outputDir)
+	if !ok {
+		return Output{}, false
+	}
+	if v, ok := r.(Validator); ok {
+		return out, v.Valid(out)
+	}
+	return out, true
+}
+
+// resolveWithRetry calls r.Resolve, retrying on failure if r.Retryable().
+// Retryable resolvers are attempted up to 3 times with 1s, 2s backoff.
+func resolveWithRetry(ctx context.Context, r Resolver, outputDir string) (Output, error) {
+	maxAttempts := 1
+	if r.Retryable() {
+		maxAttempts = 3
+	}
+
+	backoff := time.Second
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return Output{}, ctx.Err()
+		}
+		if attempt > 0 {
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return Output{}, ctx.Err()
+			case <-timer.C:
+			}
+			backoff *= 2
+		}
+
+		out, err := r.Resolve(ctx, outputDir)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+	}
+	return Output{}, lastErr
+}
+
+// touchLastUsed updates the mtime of a .last-used marker in outputDir.
+// A future cache eviction command can use this for LRU ordering.
+func touchLastUsed(outputDir string) {
+	p := filepath.Join(outputDir, ".last-used")
+	now := time.Now()
+	if err := os.Chtimes(p, now, now); err != nil {
+		// File doesn't exist yet — create it.
+		f, err := os.Create(p)
+		if err == nil {
+			f.Close()
+		}
+	}
+}

--- a/server/artifact/resolver_test.go
+++ b/server/artifact/resolver_test.go
@@ -1,0 +1,352 @@
+package artifact_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/matgreaves/rig/server/artifact"
+)
+
+// stubResolver is a test double for artifact.Resolver.
+type stubResolver struct {
+	cacheKey   string
+	output     artifact.Output
+	cachedOut  *artifact.Output // if non-nil, Cached returns this output as a hit
+	resolveN   *atomic.Int64   // counts Resolve calls
+	retryable  bool
+	resolveErr error
+}
+
+func (s *stubResolver) CacheKey() (string, error) {
+	return s.cacheKey, nil
+}
+
+func (s *stubResolver) Cached(outputDir string) (artifact.Output, bool) {
+	if s.cachedOut != nil {
+		return *s.cachedOut, true
+	}
+	// Default: check for a "binary" file in outputDir (same as GoBuild).
+	p := filepath.Join(outputDir, "binary")
+	if _, err := os.Stat(p); err != nil {
+		return artifact.Output{}, false
+	}
+	return artifact.Output{Path: p}, true
+}
+
+func (s *stubResolver) Resolve(_ context.Context, outputDir string) (artifact.Output, error) {
+	if s.resolveN != nil {
+		s.resolveN.Add(1)
+	}
+	if s.resolveErr != nil {
+		return artifact.Output{}, s.resolveErr
+	}
+	out := s.output
+	if out.Path == "" {
+		// Write a marker file so future Cached calls find it.
+		p := filepath.Join(outputDir, "binary")
+		os.WriteFile(p, []byte("stub"), 0o755) //nolint:errcheck
+		out.Path = p
+	}
+	return out, nil
+}
+
+func (s *stubResolver) Retryable() bool {
+	return s.retryable
+}
+
+// validatingResolver wraps stubResolver and implements artifact.Validator.
+type validatingResolver struct {
+	stubResolver
+	valid bool
+}
+
+func (v *validatingResolver) Valid(_ artifact.Output) bool {
+	return v.valid
+}
+
+// blockingResolver blocks until ctx is cancelled, counting how many times Resolve was called.
+type blockingResolver struct {
+	cacheKey string
+	resolveN *atomic.Int64
+}
+
+func (b *blockingResolver) CacheKey() (string, error) { return b.cacheKey, nil }
+func (b *blockingResolver) Cached(string) (artifact.Output, bool) {
+	return artifact.Output{}, false
+}
+func (b *blockingResolver) Resolve(ctx context.Context, outputDir string) (artifact.Output, error) {
+	if b.resolveN != nil {
+		b.resolveN.Add(1)
+	}
+	<-ctx.Done()
+	return artifact.Output{}, ctx.Err()
+}
+func (b *blockingResolver) Retryable() bool { return false }
+
+func TestResolve_CacheHit(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	cached := artifact.Output{Path: "/cached/binary"}
+	var called atomic.Int64
+	resolver := &stubResolver{
+		cacheKey: "abc123",
+		cachedOut: &cached, // stub reports a cache hit
+		resolveN: &called,
+	}
+
+	artifacts := []artifact.Artifact{{Key: "my-artifact", Resolver: resolver}}
+
+	results, err := artifact.Resolve(context.Background(), artifacts, cache, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if called.Load() != 0 {
+		t.Errorf("Resolve called %d times, want 0 (cache hit)", called.Load())
+	}
+
+	out, ok := results["my-artifact"]
+	if !ok {
+		t.Fatal("result missing for 'my-artifact'")
+	}
+	if out.Path != cached.Path {
+		t.Errorf("Path = %q, want %q", out.Path, cached.Path)
+	}
+}
+
+func TestResolve_Dedup(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	var called atomic.Int64
+	resolver := &stubResolver{
+		cacheKey: "shared-key",
+		resolveN: &called,
+	}
+
+	// Two artifacts with the same key — resolver should be called only once.
+	artifacts := []artifact.Artifact{
+		{Key: "artifact-a", Resolver: resolver},
+		{Key: "artifact-a", Resolver: resolver}, // duplicate key
+	}
+
+	results, err := artifact.Resolve(context.Background(), artifacts, cache, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if called.Load() != 1 {
+		t.Errorf("Resolve called %d times, want 1 (dedup)", called.Load())
+	}
+
+	if _, ok := results["artifact-a"]; !ok {
+		t.Error("result missing for 'artifact-a'")
+	}
+}
+
+func TestResolve_Parallel(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	var totalCalls atomic.Int64
+
+	makeResolver := func(key string) *stubResolver {
+		return &stubResolver{
+			cacheKey: key,
+			resolveN: &totalCalls,
+		}
+	}
+
+	artifacts := []artifact.Artifact{
+		{Key: "artifact-1", Resolver: makeResolver("key-1")},
+		{Key: "artifact-2", Resolver: makeResolver("key-2")},
+		{Key: "artifact-3", Resolver: makeResolver("key-3")},
+	}
+
+	results, err := artifact.Resolve(context.Background(), artifacts, cache, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if totalCalls.Load() != 3 {
+		t.Errorf("Resolve called %d times total, want 3", totalCalls.Load())
+	}
+
+	for _, key := range []string{"artifact-1", "artifact-2", "artifact-3"} {
+		if _, ok := results[key]; !ok {
+			t.Errorf("result missing for %q", key)
+		}
+	}
+}
+
+func TestResolve_Error(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	resolver := &stubResolver{
+		cacheKey:   "bad-key",
+		resolveErr: errors.New("build failed"),
+	}
+
+	artifacts := []artifact.Artifact{{Key: "bad-artifact", Resolver: resolver}}
+
+	_, err := artifact.Resolve(context.Background(), artifacts, cache, nil)
+	if err == nil {
+		t.Fatal("expected error from failed resolver")
+	}
+}
+
+func TestResolve_EmitEvents(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	resolver := &stubResolver{cacheKey: "emit-key"}
+	artifacts := []artifact.Artifact{{Key: "emit-artifact", Resolver: resolver}}
+
+	var events []artifact.EventKind
+	emit := func(kind artifact.EventKind, key string, err error) {
+		events = append(events, kind)
+	}
+
+	if _, err := artifact.Resolve(context.Background(), artifacts, cache, emit); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// Should emit EventStarted then EventCompleted for a cache miss.
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events, got %d: %v", len(events), events)
+	}
+	if events[0] != artifact.EventStarted {
+		t.Errorf("first event = %q, want %q", events[0], artifact.EventStarted)
+	}
+	if events[len(events)-1] != artifact.EventCompleted {
+		t.Errorf("last event = %q, want %q", events[len(events)-1], artifact.EventCompleted)
+	}
+}
+
+func TestResolve_ValidatorInvalidatesCachedResult(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	cached := artifact.Output{Path: "/cached/binary"}
+	var called atomic.Int64
+	resolver := &validatingResolver{
+		stubResolver: stubResolver{
+			cacheKey:  "val-key",
+			cachedOut: &cached,
+			resolveN:  &called,
+		},
+		valid: false, // Validator says cached result is stale
+	}
+
+	artifacts := []artifact.Artifact{{Key: "val-artifact", Resolver: resolver}}
+
+	results, err := artifact.Resolve(context.Background(), artifacts, cache, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// Resolver should have been called because Validator returned false.
+	if called.Load() != 1 {
+		t.Errorf("Resolve called %d times, want 1 (validator invalidated cache)", called.Load())
+	}
+
+	if _, ok := results["val-artifact"]; !ok {
+		t.Error("result missing for 'val-artifact'")
+	}
+}
+
+func TestResolve_ValidatorAcceptsCachedResult(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	cached := artifact.Output{Path: "/cached/binary"}
+	var called atomic.Int64
+	resolver := &validatingResolver{
+		stubResolver: stubResolver{
+			cacheKey:  "val-key-ok",
+			cachedOut: &cached,
+			resolveN:  &called,
+		},
+		valid: true, // Validator says cached result is fine
+	}
+
+	artifacts := []artifact.Artifact{{Key: "val-ok", Resolver: resolver}}
+
+	results, err := artifact.Resolve(context.Background(), artifacts, cache, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if called.Load() != 0 {
+		t.Errorf("Resolve called %d times, want 0 (validator accepted cache)", called.Load())
+	}
+
+	out, ok := results["val-ok"]
+	if !ok {
+		t.Fatal("result missing for 'val-ok'")
+	}
+	if out.Path != cached.Path {
+		t.Errorf("Path = %q, want %q", out.Path, cached.Path)
+	}
+}
+
+func TestResolve_CancelsOnFirstError(t *testing.T) {
+	cache := artifact.NewCache(t.TempDir())
+
+	var blockCalls atomic.Int64
+
+	artifacts := []artifact.Artifact{
+		{Key: "fast-fail", Resolver: &stubResolver{
+			cacheKey:   "fail-key",
+			resolveErr: errors.New("immediate failure"),
+		}},
+		{Key: "slow-block", Resolver: &blockingResolver{
+			cacheKey: "block-key",
+			resolveN: &blockCalls,
+		}},
+	}
+
+	start := time.Now()
+	_, err := artifact.Resolve(context.Background(), artifacts, cache, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// The error should mention the real failure, not context.Canceled.
+	if !strings.Contains(err.Error(), "immediate failure") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "immediate failure")
+	}
+
+	// Should complete quickly (not hang), well under 10s.
+	if elapsed > 5*time.Second {
+		t.Errorf("Resolve took %v, expected fast cancellation", elapsed)
+	}
+}
+
+func TestResolve_TouchLastUsed(t *testing.T) {
+	cacheDir := t.TempDir()
+	cache := artifact.NewCache(cacheDir)
+
+	resolver := &stubResolver{cacheKey: "touch-key"}
+	artifacts := []artifact.Artifact{{Key: "touch-artifact", Resolver: resolver}}
+
+	if _, err := artifact.Resolve(context.Background(), artifacts, cache, nil); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// .last-used should exist in the output directory.
+	outputDir := cache.OutputDir("touch-key")
+	lastUsed := filepath.Join(outputDir, ".last-used")
+	info, err := os.Stat(lastUsed)
+	if err != nil {
+		t.Fatalf(".last-used not found: %v", err)
+	}
+
+	// Should have been touched recently (within last minute).
+	if time.Since(info.ModTime()) > time.Minute {
+		t.Errorf(".last-used mtime is %v ago, expected recent", time.Since(info.ModTime()))
+	}
+}

--- a/server/lifecycle.go
+++ b/server/lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/matgreaves/rig/server/artifact"
 	"github.com/matgreaves/rig/server/ready"
 	"github.com/matgreaves/rig/server/service"
 	"github.com/matgreaves/rig/spec"
@@ -18,8 +19,9 @@ type serviceContext struct {
 	name       string
 	spec       spec.Service
 	svcType    service.Type
-	ingresses  map[string]spec.Endpoint // populated after publish
-	egresses   map[string]spec.Endpoint // populated after wiring
+	ingresses  map[string]spec.Endpoint   // populated after publish
+	egresses   map[string]spec.Endpoint   // populated after wiring
+	artifacts  map[string]artifact.Output // populated by artifact phase (shared, read-only during service phase)
 	tempDir    string
 	envDir     string
 	log        *EventLog
@@ -196,6 +198,7 @@ func runWithLifecycle(sc *serviceContext) run.Runner {
 			Spec:        sc.spec,
 			Ingresses:   sc.ingresses,
 			Egresses:    sc.egresses,
+			Artifacts:   sc.artifacts,
 			Env:         env,
 			Args:        args,
 			TempDir:     sc.tempDir,

--- a/server/orchestrator.go
+++ b/server/orchestrator.go
@@ -1,12 +1,14 @@
 package server
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 
+	"github.com/matgreaves/rig/server/artifact"
 	"github.com/matgreaves/rig/server/service"
 	"github.com/matgreaves/rig/spec"
 	"github.com/matgreaves/run"
@@ -18,12 +20,20 @@ type Orchestrator struct {
 	Registry *service.Registry
 	Log      *EventLog
 	TempBase string // base directory for temp dirs (default os.TempDir()/rig)
+	CacheDir string // artifact cache directory (default ~/.rig/cache/)
 }
 
 // Orchestrate builds a run.Runner that manages the full lifecycle of the
-// given environment. The runner starts all services concurrently using
-// run.Group. Dependency ordering emerges from services blocking on the
-// event log until their egress targets are ready.
+// given environment. The runner is a run.Sequence of two phases:
+//
+//  1. Artifact phase: resolves all required artifacts (compiled binaries, etc.)
+//     in parallel, using a content-addressable cache.
+//  2. Service phase: starts all services concurrently (run.Group). Dependency
+//     ordering emerges from services blocking on the event log until their
+//     egress targets are ready.
+//
+// The results map is safe to share because run.Sequence guarantees sequential
+// execution: the artifact phase writes to it, the service phase reads from it.
 func (o *Orchestrator) Orchestrate(env *spec.Environment) (run.Runner, string, error) {
 	// Generate instance ID.
 	instanceID := generateID()
@@ -35,32 +45,91 @@ func (o *Orchestrator) Orchestrate(env *spec.Environment) (run.Runner, string, e
 		return nil, "", fmt.Errorf("create temp dirs: %w", err)
 	}
 
-	// Build a run.Group with one lifecycle sequence per service.
-	group := run.Group{}
-
+	// Collect artifacts from all ArtifactProvider service types.
+	var allArtifacts []artifact.Artifact
 	for _, name := range serviceNames {
 		svc := env.Services[name]
-
 		svcType, err := o.Registry.Get(svc.Type)
 		if err != nil {
 			return nil, "", fmt.Errorf("service %q: %w", name, err)
 		}
-
-		sc := &serviceContext{
-			name:       name,
-			spec:       svc,
-			svcType:    svcType,
-			tempDir:    filepath.Join(envDir, name),
-			envDir:     envDir,
-			log:        o.Log,
-			envName:    env.Name,
-			instanceID: instanceID,
+		if provider, ok := svcType.(service.ArtifactProvider); ok {
+			arts, err := provider.Artifacts(service.ArtifactParams{
+				ServiceName: name,
+				Spec:        svc,
+			})
+			if err != nil {
+				return nil, "", fmt.Errorf("service %q: artifacts: %w", name, err)
+			}
+			allArtifacts = append(allArtifacts, arts...)
 		}
-
-		group[name] = serviceLifecycle(sc, o.Ports)
 	}
 
-	return group, instanceID, nil
+	// results is populated by artifactPhase and read by servicePhase.
+	// Safe because run.Sequence is sequential.
+	results := make(map[string]artifact.Output)
+
+	cache := artifact.NewCache(o.cacheDir())
+
+	emit := func(kind artifact.EventKind, key string, err error) {
+		evt := Event{
+			Environment: env.Name,
+			Artifact:    key,
+		}
+		switch kind {
+		case artifact.EventStarted:
+			evt.Type = EventArtifactStarted
+		case artifact.EventCompleted:
+			evt.Type = EventArtifactCompleted
+		case artifact.EventCached:
+			evt.Type = EventArtifactCached
+		case artifact.EventFailed:
+			evt.Type = EventArtifactFailed
+			if err != nil {
+				evt.Error = err.Error()
+			}
+		}
+		o.Log.Publish(evt)
+	}
+
+	artifactPhase := run.Func(func(ctx context.Context) error {
+		resolved, err := artifact.Resolve(ctx, allArtifacts, cache, emit)
+		if err != nil {
+			return fmt.Errorf("artifact phase: %w", err)
+		}
+		for k, v := range resolved {
+			results[k] = v
+		}
+		return nil
+	})
+
+	servicePhase := run.Func(func(ctx context.Context) error {
+		group := run.Group{}
+		for _, name := range serviceNames {
+			svc := env.Services[name]
+			svcType, err := o.Registry.Get(svc.Type)
+			if err != nil {
+				return fmt.Errorf("service %q: %w", name, err)
+			}
+
+			sc := &serviceContext{
+				name:       name,
+				spec:       svc,
+				svcType:    svcType,
+				tempDir:    filepath.Join(envDir, name),
+				envDir:     envDir,
+				log:        o.Log,
+				envName:    env.Name,
+				instanceID: instanceID,
+				artifacts:  results,
+			}
+
+			group[name] = serviceLifecycle(sc, o.Ports)
+		}
+		return group.Run(ctx)
+	})
+
+	return run.Sequence{artifactPhase, servicePhase}, instanceID, nil
 }
 
 func (o *Orchestrator) tempBase() string {
@@ -68,6 +137,18 @@ func (o *Orchestrator) tempBase() string {
 		return o.TempBase
 	}
 	return filepath.Join(os.TempDir(), "rig")
+}
+
+func (o *Orchestrator) cacheDir() string {
+	if o.CacheDir != "" {
+		return o.CacheDir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Fallback to a temp-dir-adjacent location if home is unavailable.
+		return filepath.Join(os.TempDir(), "rig-cache")
+	}
+	return filepath.Join(home, ".rig", "cache")
 }
 
 func sortedServiceNames(services map[string]spec.Service) []string {

--- a/server/server.go
+++ b/server/server.go
@@ -19,6 +19,7 @@ type Server struct {
 	ports    *PortAllocator
 	registry *service.Registry
 	tempBase string
+	cacheDir string // artifact cache directory; empty → Orchestrator default (~/.rig/cache/)
 
 	mu   sync.Mutex
 	envs map[string]*envInstance
@@ -38,17 +39,20 @@ type envInstance struct {
 
 // NewServer creates a Server and registers all HTTP routes.
 // Pass idleTimeout = 0 to disable automatic shutdown.
+// Pass cacheDir = "" to use the default artifact cache (~/.rig/cache/).
 func NewServer(
 	ports *PortAllocator,
 	registry *service.Registry,
 	tempBase string,
 	idleTimeout time.Duration,
+	cacheDir string,
 ) *Server {
 	s := &Server{
 		mux:      http.NewServeMux(),
 		ports:    ports,
 		registry: registry,
 		tempBase: tempBase,
+		cacheDir: cacheDir,
 		envs:     make(map[string]*envInstance),
 		idle:     NewIdleTimer(idleTimeout),
 	}
@@ -103,6 +107,7 @@ func (s *Server) handleCreateEnvironment(w http.ResponseWriter, r *http.Request)
 		Registry: s.registry,
 		Log:      envLog,
 		TempBase: s.tempBase,
+		CacheDir: s.cacheDir,
 	}
 
 	runner, id, err := orch.Orchestrate(&env)

--- a/server/service/gobuild.go
+++ b/server/service/gobuild.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/matgreaves/rig/server/artifact"
+	"github.com/matgreaves/rig/spec"
+	"github.com/matgreaves/run"
+)
+
+// GoServiceConfig is the type-specific config for "go" services.
+type GoServiceConfig struct {
+	// Module is an absolute local path ("/abs/path/cmd/server") or a remote
+	// module reference ("github.com/myorg/tool@v1.2.3"). The SDK resolves
+	// relative paths to absolute before sending the spec.
+	Module string `json:"module"`
+}
+
+// Go implements Type for the "go" service type. It compiles a Go module during
+// the artifact phase and runs the resulting binary during the service phase.
+type Go struct{}
+
+// Artifacts returns the GoBuild artifact for this service. Implements ArtifactProvider.
+func (Go) Artifacts(params ArtifactParams) ([]artifact.Artifact, error) {
+	var cfg GoServiceConfig
+	if params.Spec.Config == nil {
+		return nil, fmt.Errorf("service %q: missing config", params.ServiceName)
+	}
+	if err := json.Unmarshal(params.Spec.Config, &cfg); err != nil {
+		return nil, fmt.Errorf("service %q: invalid go config: %w", params.ServiceName, err)
+	}
+	if cfg.Module == "" {
+		return nil, fmt.Errorf("service %q: go config missing required \"module\" field", params.ServiceName)
+	}
+	key := artifactKey(cfg.Module)
+	return []artifact.Artifact{{
+		Key:      key,
+		Resolver: artifact.GoBuild{Module: cfg.Module},
+	}}, nil
+}
+
+// Publish resolves ingress endpoints for a go service.
+func (Go) Publish(_ context.Context, params PublishParams) (map[string]spec.Endpoint, error) {
+	return PublishLocalEndpoints(params)
+}
+
+// Runner looks up the compiled binary from the artifact results and returns a
+// run.Process that executes it with the resolved wiring.
+func (Go) Runner(params StartParams) run.Runner {
+	var cfg GoServiceConfig
+	if params.Spec.Config != nil {
+		if err := json.Unmarshal(params.Spec.Config, &cfg); err != nil {
+			return run.Func(func(context.Context) error {
+				return fmt.Errorf("service %q: invalid go config: %w", params.ServiceName, err)
+			})
+		}
+	}
+
+	key := artifactKey(cfg.Module)
+	out, ok := params.Artifacts[key]
+	if !ok {
+		return run.Func(func(context.Context) error {
+			return fmt.Errorf("service %q: artifact %q not resolved", params.ServiceName, key)
+		})
+	}
+
+	return run.Process{
+		Name:   params.ServiceName,
+		Path:   out.Path,
+		Args:   params.Args,
+		Env:    params.Env,
+		Stdout: params.Stdout,
+		Stderr: params.Stderr,
+	}
+}
+
+// artifactKey returns the dedup key for a GoBuild artifact.
+func artifactKey(module string) string {
+	return "gobuild:" + module
+}

--- a/server/service/process.go
+++ b/server/service/process.go
@@ -24,20 +24,7 @@ type Process struct{}
 
 // Publish resolves ingress endpoints for a process service.
 func (Process) Publish(_ context.Context, params PublishParams) (map[string]spec.Endpoint, error) {
-	endpoints := make(map[string]spec.Endpoint, len(params.Ingresses))
-	for name, ingSpec := range params.Ingresses {
-		port, ok := params.Ports[name]
-		if !ok {
-			return nil, fmt.Errorf("no port allocated for ingress %q", name)
-		}
-		endpoints[name] = spec.Endpoint{
-			Host:       "127.0.0.1",
-			Port:       port,
-			Protocol:   ingSpec.Protocol,
-			Attributes: ingSpec.Attributes,
-		}
-	}
-	return endpoints, nil
+	return PublishLocalEndpoints(params)
 }
 
 // Runner returns a run.Process that executes the configured binary.

--- a/server/service/type.go
+++ b/server/service/type.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/matgreaves/rig/server/artifact"
 	"github.com/matgreaves/rig/spec"
 	"github.com/matgreaves/run"
 )
@@ -21,14 +22,28 @@ type PublishParams struct {
 type StartParams struct {
 	ServiceName string
 	Spec        spec.Service
-	Ingresses   map[string]spec.Endpoint // resolved ingresses (from publish)
-	Egresses    map[string]spec.Endpoint // resolved egresses (from wiring)
-	Env         map[string]string        // pre-built environment variables
-	Args        []string                 // pre-expanded command arguments
+	Ingresses   map[string]spec.Endpoint   // resolved ingresses (from publish)
+	Egresses    map[string]spec.Endpoint   // resolved egresses (from wiring)
+	Artifacts   map[string]artifact.Output // keyed by Artifact.Key (from artifact phase)
+	Env         map[string]string          // pre-built environment variables
+	Args        []string                   // pre-expanded command arguments
 	TempDir     string
 	EnvDir      string
 	Stdout      io.Writer
 	Stderr      io.Writer
+}
+
+// ArtifactParams is passed to ArtifactProvider.Artifacts.
+type ArtifactParams struct {
+	ServiceName string
+	Spec        spec.Service
+}
+
+// ArtifactProvider is implemented by service types that require artifacts
+// (compiled binaries, pulled images, etc.) before starting. It is optional —
+// service types that have no artifacts need not implement it.
+type ArtifactProvider interface {
+	Artifacts(params ArtifactParams) ([]artifact.Artifact, error)
 }
 
 // Type defines how a service type publishes endpoints and starts.
@@ -64,4 +79,24 @@ func (r *Registry) Get(name string) (Type, error) {
 		return nil, fmt.Errorf("unknown service type: %q", name)
 	}
 	return t, nil
+}
+
+// PublishLocalEndpoints is a shared implementation of Publish for service types
+// that run locally. It maps each ingress to a 127.0.0.1 endpoint using the
+// allocated port, preserving protocol and attributes.
+func PublishLocalEndpoints(params PublishParams) (map[string]spec.Endpoint, error) {
+	endpoints := make(map[string]spec.Endpoint, len(params.Ingresses))
+	for name, ingSpec := range params.Ingresses {
+		port, ok := params.Ports[name]
+		if !ok {
+			return nil, fmt.Errorf("no port allocated for ingress %q", name)
+		}
+		endpoints[name] = spec.Endpoint{
+			Host:       "127.0.0.1",
+			Port:       port,
+			Protocol:   ingSpec.Protocol,
+			Attributes: ingSpec.Attributes,
+		}
+	}
+	return endpoints, nil
 }


### PR DESCRIPTION
Add content-addressable artifact resolution that runs before services start. All artifacts (compiled binaries, future docker pulls, downloads) are resolved in parallel with dedup, caching, and cross-process file locking.

Artifact package (server/artifact/):
- Resolver interface: CacheKey, Cached, Resolve, Retryable
- Optional Validator interface for external-store artifacts (e.g. docker images)
- Parallel resolution with dedup by artifact key, first-error cancellation
- Content-addressable cache with per-key file locks (syscall.Flock)
- Retry with exponential backoff for network-dependent resolvers
- .last-used marker files for future LRU cache eviction
- Typed EventKind constants for lifecycle events
- Prefers real errors over context.Canceled in error reporting

GoBuild resolver:
- Local modules: source-hashed cache key (GOOS, GOARCH, Go version, file contents)
- Remote modules: version-pinned cache key (requires @version suffix)
- git ls-files with fallback to filepath.WalkDir for source enumeration
- Includes untracked Go files, filters to .go/go.mod/go.sum, sorted for determinism
- Relative paths in hash for checkout-location independence
- -trimpath for reproducible binaries, partial output cleanup on failure
- Known limitations documented (replace directives, //go:embed assets)

Orchestrator changes:
- Two-phase execution: run.Sequence{artifactPhase, servicePhase}
- Collects artifacts from ArtifactProvider service types before resolution
- Artifact events emitted to EventLog (started, completed, cached, failed)
- Configurable CacheDir (default ~/.rig/cache/)

Service type changes:
- ArtifactProvider interface (optional, returns error)
- Go service type: compiles module in artifact phase, runs binary in service phase
- PublishLocalEndpoints shared helper (used by Process and Go)
- Artifacts field added to StartParams