### PR TITLE
phase 6: Go client SDK and connect module

### DIFF
--- a/client/convert.go
+++ b/client/convert.go
@@ -1,0 +1,196 @@
+package rig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/matgreaves/rig/spec"
+)
+
+// hookSeq generates unique hook names across the process.
+var hookSeq atomic.Uint64
+
+// envToSpec converts the SDK Services to the spec.Environment wire format.
+// Hook functions are registered in handlers keyed by their generated name.
+func envToSpec(testName string, services Services, handlers map[string]hookFunc) (spec.Environment, error) {
+	specs := make(map[string]spec.Service, len(services))
+	for name, def := range services {
+		svc, err := serviceToSpec(def, handlers)
+		if err != nil {
+			return spec.Environment{}, fmt.Errorf("service %q: %w", name, err)
+		}
+		specs[name] = svc
+	}
+	return spec.Environment{
+		Name:     testName,
+		Services: specs,
+	}, nil
+}
+
+func serviceToSpec(def ServiceDef, handlers map[string]hookFunc) (spec.Service, error) {
+	switch d := def.(type) {
+	case *GoDef:
+		return goToSpec(d, handlers)
+	case *ProcessDef:
+		return processToSpec(d, handlers)
+	case *CustomDef:
+		return customToSpec(d, handlers)
+	default:
+		return spec.Service{}, fmt.Errorf("unknown service type: %T", def)
+	}
+}
+
+func goToSpec(d *GoDef, handlers map[string]hookFunc) (spec.Service, error) {
+	module := d.module
+	if !filepath.IsAbs(module) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return spec.Service{}, fmt.Errorf("resolve module path: %w", err)
+		}
+		module = filepath.Join(wd, module)
+	}
+
+	cfg, _ := json.Marshal(map[string]string{"module": module})
+
+	hooks, err := hooksToSpec(d.hooks, handlers)
+	if err != nil {
+		return spec.Service{}, err
+	}
+
+	return spec.Service{
+		Type:      "go",
+		Config:    cfg,
+		Args:      d.args,
+		Ingresses: ingressesToSpec(d.ingresses),
+		Egresses:  egressesToSpec(d.egresses),
+		Hooks:     hooks,
+	}, nil
+}
+
+func processToSpec(d *ProcessDef, handlers map[string]hookFunc) (spec.Service, error) {
+	cfg, _ := json.Marshal(map[string]string{"command": d.command, "dir": d.dir})
+
+	hooks, err := hooksToSpec(d.hooks, handlers)
+	if err != nil {
+		return spec.Service{}, err
+	}
+
+	return spec.Service{
+		Type:      "process",
+		Config:    cfg,
+		Args:      d.args,
+		Ingresses: ingressesToSpec(d.ingresses),
+		Egresses:  egressesToSpec(d.egresses),
+		Hooks:     hooks,
+	}, nil
+}
+
+func customToSpec(d *CustomDef, handlers map[string]hookFunc) (spec.Service, error) {
+	var cfg json.RawMessage
+	if d.config != nil {
+		var err error
+		cfg, err = json.Marshal(d.config)
+		if err != nil {
+			return spec.Service{}, fmt.Errorf("marshal custom config: %w", err)
+		}
+	}
+
+	hooks, err := hooksToSpec(d.hooks, handlers)
+	if err != nil {
+		return spec.Service{}, err
+	}
+
+	return spec.Service{
+		Type:      d.svcType,
+		Config:    cfg,
+		Args:      d.args,
+		Ingresses: ingressesToSpec(d.ingresses),
+		Egresses:  egressesToSpec(d.egresses),
+		Hooks:     hooks,
+	}, nil
+}
+
+func ingressesToSpec(ingresses map[string]IngressDef) map[string]spec.IngressSpec {
+	if len(ingresses) == 0 {
+		return nil
+	}
+	out := make(map[string]spec.IngressSpec, len(ingresses))
+	for name, ing := range ingresses {
+		s := spec.IngressSpec{
+			Protocol:      spec.Protocol(ing.Protocol),
+			ContainerPort: ing.ContainerPort,
+			Attributes:    ing.Attributes,
+		}
+		if ing.Ready != nil {
+			s.Ready = &spec.ReadySpec{
+				Type: ing.Ready.Type,
+				Path: ing.Ready.Path,
+			}
+			if ing.Ready.Interval > 0 {
+				s.Ready.Interval = spec.Duration{Duration: ing.Ready.Interval}
+			}
+			if ing.Ready.Timeout > 0 {
+				s.Ready.Timeout = spec.Duration{Duration: ing.Ready.Timeout}
+			}
+		}
+		out[name] = s
+	}
+	return out
+}
+
+func egressesToSpec(egresses map[string]egressDef) map[string]spec.EgressSpec {
+	if len(egresses) == 0 {
+		return nil
+	}
+	out := make(map[string]spec.EgressSpec, len(egresses))
+	for name, eg := range egresses {
+		out[name] = spec.EgressSpec{
+			Service: eg.service,
+			Ingress: eg.ingress,
+		}
+	}
+	return out
+}
+
+func hooksToSpec(h hooksDef, handlers map[string]hookFunc) (*spec.Hooks, error) {
+	if h.prestart == nil && h.init == nil {
+		return nil, nil
+	}
+
+	var hooks spec.Hooks
+
+	if h.prestart != nil {
+		hs, err := hookToSpec(h.prestart, handlers)
+		if err != nil {
+			return nil, fmt.Errorf("prestart: %w", err)
+		}
+		hooks.Prestart = hs
+	}
+
+	if h.init != nil {
+		hs, err := hookToSpec(h.init, handlers)
+		if err != nil {
+			return nil, fmt.Errorf("init: %w", err)
+		}
+		hooks.Init = hs
+	}
+
+	return &hooks, nil
+}
+
+func hookToSpec(h hook, handlers map[string]hookFunc) (*spec.HookSpec, error) {
+	switch hk := h.(type) {
+	case hookFunc:
+		name := fmt.Sprintf("_hook_%d", hookSeq.Add(1))
+		handlers[name] = hk
+		return &spec.HookSpec{
+			Type:       "client_func",
+			ClientFunc: &spec.ClientFuncSpec{Name: name},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported hook type: %T", h)
+	}
+}

--- a/client/environment.go
+++ b/client/environment.go
@@ -1,0 +1,62 @@
+package rig
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Environment is the resolved, running environment returned by Up.
+// It provides methods to look up service endpoints.
+type Environment struct {
+	ID       string
+	Name     string
+	Services map[string]ResolvedService
+}
+
+// ResolvedService holds the resolved endpoints for a single service.
+type ResolvedService struct {
+	Ingresses map[string]Endpoint
+}
+
+// Endpoint returns the ingress endpoint for the named service. If ingress
+// is omitted, the default ingress is returned. If the service has a single
+// ingress, it is returned regardless of its name.
+//
+// Panics with a descriptive message if the service or ingress is not found.
+func (e *Environment) Endpoint(service string, ingress ...string) Endpoint {
+	svc, ok := e.Services[service]
+	if !ok {
+		panic(fmt.Sprintf("rig: service %q not found in environment %q (available: %s)",
+			service, e.Name, sortedKeys(e.Services)))
+	}
+
+	ingressName := "default"
+	if len(ingress) > 0 {
+		ingressName = ingress[0]
+	}
+
+	// Single ingress shorthand: if the service has exactly one ingress
+	// and no specific name was requested, return it.
+	if ingressName == "default" && len(svc.Ingresses) == 1 {
+		for _, ep := range svc.Ingresses {
+			return ep
+		}
+	}
+
+	ep, ok := svc.Ingresses[ingressName]
+	if !ok {
+		panic(fmt.Sprintf("rig: ingress %q not found on service %q (available: %s)",
+			ingressName, service, sortedKeys(svc.Ingresses)))
+	}
+	return ep
+}
+
+func sortedKeys[V any](m map[string]V) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("%v", keys)
+}
+

--- a/client/rig.go
+++ b/client/rig.go
@@ -1,0 +1,226 @@
+package rig
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matgreaves/rig/connect"
+)
+
+// Re-export shared types from connect/ so users of the SDK never need to
+// import connect/ directly.
+type (
+	Endpoint = connect.Endpoint
+	Protocol = connect.Protocol
+	Wiring   = connect.Wiring
+)
+
+const (
+	TCP  = connect.TCP
+	HTTP = connect.HTTP
+	GRPC = connect.GRPC
+)
+
+// Services maps service names to their definitions.
+type Services map[string]ServiceDef
+
+// ServiceDef is the interface implemented by all service type builders
+// (*GoDef, *ProcessDef, *CustomDef). It is sealed — only types in this
+// package implement it.
+type ServiceDef interface {
+	rigService()
+}
+
+// IngressDef defines an endpoint a service exposes. Use the IngressHTTP,
+// IngressTCP, or IngressGRPC constructors for the common case. For full
+// control (health check overrides, attributes, container ports), use a
+// struct literal:
+//
+//	rig.IngressDef{
+//	    Protocol:   rig.HTTP,
+//	    Ready:      &rig.ReadyDef{Path: "/healthz"},
+//	    Attributes: map[string]any{"KEY": "value"},
+//	}
+type IngressDef struct {
+	Protocol      Protocol
+	ContainerPort int            // for container types only
+	Ready         *ReadyDef      // optional health check override
+	Attributes    map[string]any // static attributes published with this ingress
+}
+
+// IngressHTTP returns an IngressDef for an HTTP endpoint.
+func IngressHTTP() IngressDef { return IngressDef{Protocol: HTTP} }
+
+// IngressTCP returns an IngressDef for a TCP endpoint.
+func IngressTCP() IngressDef { return IngressDef{Protocol: TCP} }
+
+// IngressGRPC returns an IngressDef for a gRPC endpoint.
+func IngressGRPC() IngressDef { return IngressDef{Protocol: GRPC} }
+
+// ReadyDef overrides the health check for an ingress.
+type ReadyDef struct {
+	Type     string        // "tcp", "http", "grpc"
+	Path     string        // HTTP check path
+	Interval time.Duration // poll interval
+	Timeout  time.Duration // max wait
+}
+
+// Internal types — used by service builders but not exposed to users.
+
+type egressDef struct {
+	service string
+	ingress string
+}
+
+type hooksDef struct {
+	prestart hook
+	init     hook
+}
+
+type hook interface {
+	rigHook()
+}
+
+type hookFunc func(ctx context.Context, w Wiring) error
+
+func (hookFunc) rigHook() {}
+
+// Option configures the behavior of Up.
+type Option func(*options)
+
+type options struct {
+	serverURL      string
+	startupTimeout time.Duration
+}
+
+func defaultOptions() options {
+	return options{
+		serverURL:      os.Getenv("RIG_SERVER_ADDR"),
+		startupTimeout: 2 * time.Minute,
+	}
+}
+
+// WithServer sets the rigd server base URL (e.g. "http://127.0.0.1:8080").
+// Defaults to the RIG_SERVER_ADDR environment variable.
+func WithServer(url string) Option {
+	return func(o *options) { o.serverURL = url }
+}
+
+// WithTimeout sets the maximum time to wait for the environment to become
+// ready. Default is 2 minutes.
+func WithTimeout(d time.Duration) Option {
+	return func(o *options) { o.startupTimeout = d }
+}
+
+// Up creates an environment, blocks until all services are ready, and
+// registers cleanup with t.Cleanup to tear down the environment when the
+// test finishes.
+//
+// If any step fails (server connection, spec validation, service startup),
+// Up calls t.Fatal with a descriptive error message.
+func Up(t testing.TB, services Services, opts ...Option) *Environment {
+	t.Helper()
+
+	o := defaultOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	if o.serverURL == "" {
+		t.Fatal("rig: no server address; set RIG_SERVER_ADDR or use rig.WithServer()")
+	}
+
+	// Trim trailing slash for consistent URL construction.
+	o.serverURL = strings.TrimRight(o.serverURL, "/")
+
+	// Collect hook handlers during spec conversion.
+	handlers := make(map[string]hookFunc)
+	specEnv, err := envToSpec(t.Name(), services, handlers)
+	if err != nil {
+		t.Fatalf("rig: build spec: %v", err)
+	}
+
+	// POST /environments
+	body, err := json.Marshal(specEnv)
+	if err != nil {
+		t.Fatalf("rig: marshal spec: %v", err)
+	}
+
+	resp, err := http.Post(
+		o.serverURL+"/environments",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("rig: create environment: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		var result struct {
+			ValidationErrors []string `json:"validation_errors"`
+		}
+		json.NewDecoder(resp.Body).Decode(&result)
+		t.Fatalf("rig: spec validation failed:\n  %s",
+			strings.Join(result.ValidationErrors, "\n  "))
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("rig: create environment: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("rig: decode create response: %v", err)
+	}
+
+	envID := created.ID
+
+	// Register cleanup: DELETE the environment on test completion.
+	t.Cleanup(func() {
+		destroyEnvironment(o.serverURL, envID)
+	})
+
+	// Open SSE stream and process events until environment.up or failure.
+	ctx, cancel := context.WithTimeout(context.Background(), o.startupTimeout)
+	defer cancel()
+
+	resolved, err := streamUntilReady(ctx, t, o.serverURL, envID, handlers)
+	if err != nil {
+		t.Fatalf("rig: %v", err)
+	}
+
+	resolved.ID = envID
+	resolved.Name = t.Name()
+
+	return resolved
+}
+
+// destroyEnvironment sends DELETE /environments/{id}. Blocks until teardown
+// completes. Errors are swallowed — cleanup must not abort other tests.
+func destroyEnvironment(serverURL, envID string) {
+	req, err := http.NewRequest(
+		http.MethodDelete,
+		fmt.Sprintf("%s/environments/%s", serverURL, envID),
+		nil,
+	)
+	if err != nil {
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}

--- a/client/rig_test.go
+++ b/client/rig_test.go
@@ -1,0 +1,317 @@
+package rig_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	rig "github.com/matgreaves/rig/client"
+	"github.com/matgreaves/rig/connect/httpx"
+	"github.com/matgreaves/rig/server"
+	"github.com/matgreaves/rig/server/service"
+)
+
+// moduleRoot returns the module root by finding go.mod relative to the test
+// working directory.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod")
+		}
+		dir = parent
+	}
+}
+
+// startTestServer creates an httptest.Server backed by a real server.Server
+// with process and go service types registered. Returns the server URL.
+func startTestServer(t *testing.T) string {
+	t.Helper()
+	reg := service.NewRegistry()
+	reg.Register("process", service.Process{})
+	reg.Register("go", service.Go{})
+
+	s := server.NewServer(
+		server.NewPortAllocator(),
+		reg,
+		t.TempDir(),
+		0,           // idle timeout disabled
+		t.TempDir(), // isolated artifact cache
+	)
+	ts := httptest.NewServer(s)
+	t.Cleanup(ts.Close)
+	return ts.URL
+}
+
+func TestUp_GoService(t *testing.T) {
+	root := moduleRoot(t)
+	serverURL := startTestServer(t)
+
+	env := rig.Up(t, rig.Services{
+		"echo": rig.Go(filepath.Join(root, "testdata", "services", "echo")),
+	}, rig.WithServer(serverURL), rig.WithTimeout(60*time.Second))
+
+	client := httpx.New(env.Endpoint("echo"))
+	resp, err := client.Get("/health")
+	if err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("health: %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestUp_ProcessService(t *testing.T) {
+	root := moduleRoot(t)
+	serverURL := startTestServer(t)
+
+	// Build the echo binary first since "process" type needs a pre-built binary.
+	echoBin := buildBinary(t, filepath.Join(root, "testdata", "services", "echo"))
+
+	env := rig.Up(t, rig.Services{
+		"echo": rig.Process(echoBin),
+	}, rig.WithServer(serverURL), rig.WithTimeout(30*time.Second))
+
+	client := httpx.New(env.Endpoint("echo"))
+	resp, err := client.Get("/health")
+	if err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("health: %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestUp_WithDependency(t *testing.T) {
+	root := moduleRoot(t)
+	serverURL := startTestServer(t)
+
+	env := rig.Up(t, rig.Services{
+		"db": rig.Go(filepath.Join(root, "testdata", "services", "tcpecho")).
+			Ingress("default", rig.IngressTCP()),
+		"api": rig.Go(filepath.Join(root, "testdata", "services", "echo")).
+			EgressAs("database", "db"),
+	}, rig.WithServer(serverURL), rig.WithTimeout(60*time.Second))
+
+	// API should be reachable.
+	client := httpx.New(env.Endpoint("api"))
+	resp, err := client.Get("/health")
+	if err != nil {
+		t.Fatalf("api health check: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("api health: %d, want 200", resp.StatusCode)
+	}
+
+	// DB should be reachable via TCP.
+	conn, err := net.DialTimeout("tcp", env.Endpoint("db").Addr(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("db dial: %v", err)
+	}
+	conn.Close()
+}
+
+func TestUp_InitHook(t *testing.T) {
+	root := moduleRoot(t)
+	serverURL := startTestServer(t)
+
+	var hookCalled bool
+	var wiringSnapshot rig.Wiring
+
+	env := rig.Up(t, rig.Services{
+		"echo": rig.Go(filepath.Join(root, "testdata", "services", "echo")).
+			InitHook(func(ctx context.Context, w rig.Wiring) error {
+				hookCalled = true
+				wiringSnapshot = w
+				return nil
+			}),
+	}, rig.WithServer(serverURL), rig.WithTimeout(60*time.Second))
+
+	if !hookCalled {
+		t.Fatal("init hook was not called")
+	}
+
+	// Init hooks receive ingresses.
+	if len(wiringSnapshot.Ingresses) == 0 {
+		t.Error("init hook received no ingresses")
+	}
+
+	// Init hooks do NOT receive egresses.
+	if len(wiringSnapshot.Egresses) != 0 {
+		t.Errorf("init hook received egresses (should be empty): %v", wiringSnapshot.Egresses)
+	}
+
+	// Service should be reachable.
+	client := httpx.New(env.Endpoint("echo"))
+	resp, err := client.Get("/health")
+	if err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("health: %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestUp_PrestartHook(t *testing.T) {
+	root := moduleRoot(t)
+	serverURL := startTestServer(t)
+
+	var wiringSnapshot rig.Wiring
+
+	rig.Up(t, rig.Services{
+		"db": rig.Go(filepath.Join(root, "testdata", "services", "tcpecho")).
+			Ingress("default", rig.IngressTCP()),
+		"api": rig.Go(filepath.Join(root, "testdata", "services", "echo")).
+			EgressAs("database", "db").
+			PrestartHook(func(ctx context.Context, w rig.Wiring) error {
+				wiringSnapshot = w
+				return nil
+			}),
+	}, rig.WithServer(serverURL), rig.WithTimeout(60*time.Second))
+
+	// Prestart hooks receive egresses.
+	if _, ok := wiringSnapshot.Egresses["database"]; !ok {
+		t.Error("prestart hook did not receive 'database' egress")
+	}
+
+	// Prestart hooks also receive ingresses.
+	if len(wiringSnapshot.Ingresses) == 0 {
+		t.Error("prestart hook received no ingresses")
+	}
+}
+
+func TestEndpoint_Lookup(t *testing.T) {
+	env := &rig.Environment{
+		Name: "test",
+		Services: map[string]rig.ResolvedService{
+			"api": {Ingresses: map[string]rig.Endpoint{
+				"default": {Host: "127.0.0.1", Port: 8080, Protocol: rig.HTTP},
+				"grpc":    {Host: "127.0.0.1", Port: 9090, Protocol: rig.GRPC},
+			}},
+			"db": {Ingresses: map[string]rig.Endpoint{
+				"tcp": {Host: "127.0.0.1", Port: 5432, Protocol: rig.TCP},
+			}},
+		},
+	}
+
+	// Default ingress by name.
+	ep := env.Endpoint("api")
+	if ep.Port != 8080 {
+		t.Errorf("api default port = %d, want 8080", ep.Port)
+	}
+
+	// Named ingress.
+	ep = env.Endpoint("api", "grpc")
+	if ep.Port != 9090 {
+		t.Errorf("api grpc port = %d, want 9090", ep.Port)
+	}
+
+	// Single ingress shorthand — returns sole ingress even if not named "default".
+	ep = env.Endpoint("db")
+	if ep.Port != 5432 {
+		t.Errorf("db port = %d, want 5432", ep.Port)
+	}
+}
+
+func TestEndpoint_Lookup_PanicsOnMiss(t *testing.T) {
+	env := &rig.Environment{
+		Name: "test",
+		Services: map[string]rig.ResolvedService{
+			"api": {Ingresses: map[string]rig.Endpoint{
+				"default": {Host: "127.0.0.1", Port: 8080, Protocol: rig.HTTP},
+			}},
+		},
+	}
+
+	// Unknown service.
+	assertPanics(t, "unknown service", func() {
+		env.Endpoint("nonexistent")
+	})
+
+	// Unknown ingress.
+	assertPanics(t, "unknown ingress", func() {
+		env.Endpoint("api", "nonexistent")
+	})
+}
+
+func TestEndpoint_ConnectionHelpers(t *testing.T) {
+	httpEP := rig.Endpoint{Host: "127.0.0.1", Port: 8080, Protocol: rig.HTTP}
+	if got := httpEP.Addr(); got != "127.0.0.1:8080" {
+		t.Errorf("HTTP Addr = %q, want 127.0.0.1:8080", got)
+	}
+
+	grpcEP := rig.Endpoint{Host: "127.0.0.1", Port: 9090, Protocol: rig.GRPC}
+	if got := grpcEP.Addr(); got != "127.0.0.1:9090" {
+		t.Errorf("GRPC Addr = %q, want 127.0.0.1:9090", got)
+	}
+
+	tcpEP := rig.Endpoint{Host: "127.0.0.1", Port: 5432, Protocol: rig.TCP}
+	if got := tcpEP.Addr(); got != "127.0.0.1:5432" {
+		t.Errorf("TCP Addr = %q, want 127.0.0.1:5432", got)
+	}
+}
+
+func TestEndpoint_Attr(t *testing.T) {
+	ep := rig.Endpoint{
+		Host:     "127.0.0.1",
+		Port:     5432,
+		Protocol: rig.TCP,
+		Attributes: map[string]any{
+			"PGDATABASE": "testdb",
+			"PGUSER":     "postgres",
+			"PORT":       5432,
+		},
+	}
+
+	if got := ep.Attr("PGDATABASE"); got != "testdb" {
+		t.Errorf("Attr(PGDATABASE) = %q, want testdb", got)
+	}
+	if got := ep.Attr("PORT"); got != "5432" {
+		t.Errorf("Attr(PORT) = %q, want 5432", got)
+	}
+	if got := ep.Attr("MISSING"); got != "" {
+		t.Errorf("Attr(MISSING) = %q, want empty", got)
+	}
+}
+
+// --- helpers ---
+
+func assertPanics(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("%s: expected panic, got none", name)
+		}
+	}()
+	fn()
+}
+
+func buildBinary(t *testing.T, srcDir string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), filepath.Base(srcDir))
+	cmd := exec.Command("go", "build", "-o", bin, srcDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build %s: %v\n%s", srcDir, err, out)
+	}
+	return bin
+}

--- a/client/services.go
+++ b/client/services.go
@@ -1,0 +1,252 @@
+package rig
+
+import "context"
+
+// GoDef defines a service built from a Go module. Use the Go() constructor
+// for the common case, or create a GoDef literal for full control.
+type GoDef struct {
+	module    string
+	args      []string
+	ingresses map[string]IngressDef
+	egresses  map[string]egressDef
+	hooks     hooksDef
+}
+
+func (*GoDef) rigService() {}
+
+// Go creates a Go service definition with a default HTTP ingress.
+// The module path is resolved relative to the working directory if not absolute.
+//
+// Chain methods to customize:
+//
+//	rig.Go("./cmd/api").
+//	    Egress("postgres").
+//	    InitHook(func(ctx context.Context, w rig.Wiring) error { ... })
+func Go(module string) *GoDef {
+	return &GoDef{
+		module:    module,
+		ingresses: map[string]IngressDef{"default": IngressHTTP()},
+	}
+}
+
+// NoIngress removes all ingresses, for services that are pure workers
+// with only egress dependencies.
+func (d *GoDef) NoIngress() *GoDef {
+	d.ingresses = nil
+	return d
+}
+
+// Ingress adds or overrides an ingress on the service.
+func (d *GoDef) Ingress(name string, def IngressDef) *GoDef {
+	if d.ingresses == nil {
+		d.ingresses = make(map[string]IngressDef)
+	}
+	d.ingresses[name] = def
+	return d
+}
+
+// Egress adds a dependency on a service. The egress is named after the
+// target service. If ingress is provided, it specifies which ingress on the
+// target; otherwise the target's sole ingress is used.
+//
+//	.Egress("postgres")           // egress "postgres" → postgres default
+//	.Egress("postgres", "admin")  // egress "postgres" → postgres/admin
+func (d *GoDef) Egress(service string, ingress ...string) *GoDef {
+	return d.EgressAs(service, service, ingress...)
+}
+
+// EgressAs adds a dependency with a custom local name. Use this when the
+// egress name should differ from the target service name, e.g. when a
+// service depends on the same target twice via different ingresses.
+//
+//	.EgressAs("db", "postgres")           // egress "db" → postgres default
+//	.EgressAs("db", "postgres", "admin")  // egress "db" → postgres/admin
+func (d *GoDef) EgressAs(name, service string, ingress ...string) *GoDef {
+	if d.egresses == nil {
+		d.egresses = make(map[string]egressDef)
+	}
+	eg := egressDef{service: service}
+	if len(ingress) > 0 {
+		eg.ingress = ingress[0]
+	}
+	d.egresses[name] = eg
+	return d
+}
+
+// Args sets command-line arguments (supports ${VAR} expansion).
+func (d *GoDef) Args(args ...string) *GoDef {
+	d.args = args
+	return d
+}
+
+// InitHook registers a client-side function that runs after health checks
+// pass, before the service is marked ready. Receives own ingresses only.
+func (d *GoDef) InitHook(fn func(ctx context.Context, w Wiring) error) *GoDef {
+	d.hooks.init = hookFunc(fn)
+	return d
+}
+
+// PrestartHook registers a client-side function that runs after egresses
+// are resolved, before the service process starts. Receives full wiring.
+func (d *GoDef) PrestartHook(fn func(ctx context.Context, w Wiring) error) *GoDef {
+	d.hooks.prestart = hookFunc(fn)
+	return d
+}
+
+// ProcessDef defines a service that runs a pre-built binary. Use the
+// Process() constructor or create a ProcessDef literal for full control.
+type ProcessDef struct {
+	command   string
+	dir       string
+	args      []string
+	ingresses map[string]IngressDef
+	egresses  map[string]egressDef
+	hooks     hooksDef
+}
+
+func (*ProcessDef) rigService() {}
+
+// Process creates a process service definition with a default HTTP ingress.
+// The command must be the path to a pre-built binary.
+//
+//	rig.Process("/path/to/binary").
+//	    Egress("postgres")
+func Process(command string) *ProcessDef {
+	return &ProcessDef{
+		command:   command,
+		ingresses: map[string]IngressDef{"default": IngressHTTP()},
+	}
+}
+
+// NoIngress removes all ingresses, for services that are pure workers
+// with only egress dependencies.
+func (d *ProcessDef) NoIngress() *ProcessDef {
+	d.ingresses = nil
+	return d
+}
+
+// Dir sets the working directory for the process.
+func (d *ProcessDef) Dir(dir string) *ProcessDef {
+	d.dir = dir
+	return d
+}
+
+// Ingress adds or overrides an ingress on the service.
+func (d *ProcessDef) Ingress(name string, def IngressDef) *ProcessDef {
+	if d.ingresses == nil {
+		d.ingresses = make(map[string]IngressDef)
+	}
+	d.ingresses[name] = def
+	return d
+}
+
+// Egress adds a dependency on a service, named after the target.
+func (d *ProcessDef) Egress(service string, ingress ...string) *ProcessDef {
+	return d.EgressAs(service, service, ingress...)
+}
+
+// EgressAs adds a dependency with a custom local name.
+func (d *ProcessDef) EgressAs(name, service string, ingress ...string) *ProcessDef {
+	if d.egresses == nil {
+		d.egresses = make(map[string]egressDef)
+	}
+	eg := egressDef{service: service}
+	if len(ingress) > 0 {
+		eg.ingress = ingress[0]
+	}
+	d.egresses[name] = eg
+	return d
+}
+
+// Args sets command-line arguments (supports ${VAR} expansion).
+func (d *ProcessDef) Args(args ...string) *ProcessDef {
+	d.args = args
+	return d
+}
+
+// InitHook registers a client-side init hook function.
+func (d *ProcessDef) InitHook(fn func(ctx context.Context, w Wiring) error) *ProcessDef {
+	d.hooks.init = hookFunc(fn)
+	return d
+}
+
+// PrestartHook registers a client-side prestart hook function.
+func (d *ProcessDef) PrestartHook(fn func(ctx context.Context, w Wiring) error) *ProcessDef {
+	d.hooks.prestart = hookFunc(fn)
+	return d
+}
+
+// CustomDef defines a service using any server-registered type. This is the
+// escape hatch for types not yet modeled in the SDK.
+type CustomDef struct {
+	svcType   string
+	config    map[string]any
+	args      []string
+	ingresses map[string]IngressDef
+	egresses  map[string]egressDef
+	hooks     hooksDef
+}
+
+func (*CustomDef) rigService() {}
+
+// Custom creates a service definition for any server-registered type,
+// with a default HTTP ingress.
+func Custom(svcType string, config map[string]any) *CustomDef {
+	return &CustomDef{
+		svcType:   svcType,
+		config:    config,
+		ingresses: map[string]IngressDef{"default": IngressHTTP()},
+	}
+}
+
+// NoIngress removes all ingresses, for services that are pure workers
+// with only egress dependencies.
+func (d *CustomDef) NoIngress() *CustomDef {
+	d.ingresses = nil
+	return d
+}
+
+// Ingress adds or overrides an ingress on the service.
+func (d *CustomDef) Ingress(name string, def IngressDef) *CustomDef {
+	if d.ingresses == nil {
+		d.ingresses = make(map[string]IngressDef)
+	}
+	d.ingresses[name] = def
+	return d
+}
+
+// Egress adds a dependency on a service, named after the target.
+func (d *CustomDef) Egress(service string, ingress ...string) *CustomDef {
+	return d.EgressAs(service, service, ingress...)
+}
+
+// EgressAs adds a dependency with a custom local name.
+func (d *CustomDef) EgressAs(name, service string, ingress ...string) *CustomDef {
+	if d.egresses == nil {
+		d.egresses = make(map[string]egressDef)
+	}
+	eg := egressDef{service: service}
+	if len(ingress) > 0 {
+		eg.ingress = ingress[0]
+	}
+	d.egresses[name] = eg
+	return d
+}
+
+// Args sets command-line arguments.
+func (d *CustomDef) Args(args ...string) *CustomDef {
+	d.args = args
+	return d
+}
+
+// InitHook registers a client-side init hook function.
+func (d *CustomDef) InitHook(fn func(ctx context.Context, w Wiring) error) *CustomDef {
+	d.hooks.init = hookFunc(fn)
+	return d
+}
+
+// PrestartHook registers a client-side prestart hook function.
+func (d *CustomDef) PrestartHook(fn func(ctx context.Context, w Wiring) error) *CustomDef {
+	d.hooks.prestart = hookFunc(fn)
+	return d
+}

--- a/client/stream.go
+++ b/client/stream.go
@@ -1,0 +1,280 @@
+package rig
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// wireEvent mirrors the server's Event type for JSON decoding from the SSE
+// stream. Only the fields the SDK needs are included.
+type wireEvent struct {
+	Type      string                                `json:"type"`
+	Service   string                                `json:"service,omitempty"`
+	Ingress   string                                `json:"ingress,omitempty"`
+	Artifact  string                                `json:"artifact,omitempty"`
+	Error     string                                `json:"error,omitempty"`
+	Log       *wireLogEntry                         `json:"log,omitempty"`
+	Callback  *wireCallbackRequest                  `json:"callback,omitempty"`
+	Ingresses map[string]map[string]wireEndpoint    `json:"ingresses,omitempty"`
+}
+
+type wireLogEntry struct {
+	Stream string `json:"stream"`
+	Data   string `json:"data"`
+}
+
+type wireCallbackRequest struct {
+	RequestID string             `json:"request_id"`
+	Name      string             `json:"name"`
+	Type      string             `json:"type"`
+	Wiring    *wireWiringContext  `json:"wiring,omitempty"`
+}
+
+type wireWiringContext struct {
+	Ingresses  map[string]wireEndpoint `json:"ingresses,omitempty"`
+	Egresses   map[string]wireEndpoint `json:"egresses,omitempty"`
+	TempDir    string                  `json:"temp_dir,omitempty"`
+	EnvDir     string                  `json:"env_dir,omitempty"`
+	Attributes map[string]string       `json:"attributes,omitempty"`
+}
+
+type wireEndpoint struct {
+	Host       string         `json:"host"`
+	Port       int            `json:"port"`
+	Protocol   Protocol       `json:"protocol"`
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+type wireCallbackResponse struct {
+	RequestID string         `json:"request_id"`
+	Error     string         `json:"error,omitempty"`
+	Data      map[string]any `json:"data,omitempty"`
+}
+
+// streamUntilReady connects to the SSE stream and processes events until
+// environment.up arrives (success) or environment.down arrives (failure).
+func streamUntilReady(
+	ctx context.Context,
+	t testing.TB,
+	serverURL string,
+	envID string,
+	handlers map[string]hookFunc,
+) (*Environment, error) {
+	url := fmt.Sprintf("%s/environments/%s/events", serverURL, envID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create SSE request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connect to event stream: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("event stream: HTTP %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var eventType, data string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			eventType = strings.TrimPrefix(line, "event: ")
+
+		case strings.HasPrefix(line, "data: "):
+			data = strings.TrimPrefix(line, "data: ")
+
+		case line == "":
+			if eventType == "" || data == "" {
+				eventType, data = "", ""
+				continue
+			}
+
+			var ev wireEvent
+			if err := json.Unmarshal([]byte(data), &ev); err != nil {
+				eventType, data = "", ""
+				continue
+			}
+
+			result, done, err := handleEvent(ctx, t, serverURL, envID, ev, handlers)
+			if err != nil {
+				return nil, err
+			}
+			if done {
+				return result, nil
+			}
+
+			eventType, data = "", ""
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("event stream read: %w", err)
+	}
+
+	return nil, fmt.Errorf("event stream closed before environment.up")
+}
+
+// handleEvent processes a single SSE event. Returns (result, done, error).
+func handleEvent(
+	ctx context.Context,
+	t testing.TB,
+	serverURL string,
+	envID string,
+	ev wireEvent,
+	handlers map[string]hookFunc,
+) (*Environment, bool, error) {
+	switch ev.Type {
+	case "callback.request":
+		if ev.Callback == nil {
+			return nil, false, nil
+		}
+		if err := dispatchCallback(ctx, serverURL, envID, ev.Callback, handlers); err != nil {
+			return nil, false, fmt.Errorf("callback %q: %w", ev.Callback.Name, err)
+		}
+
+	case "environment.up":
+		resolved := buildEnvironmentFromEvent(ev)
+		return resolved, true, nil
+
+	case "environment.down":
+		return nil, false, fmt.Errorf("environment failed (received environment.down without environment.up)")
+
+	case "service.log":
+		if ev.Log != nil {
+			t.Logf("rig: %s | %s", ev.Service, strings.TrimRight(ev.Log.Data, "\n"))
+		}
+
+	case "service.failed":
+		t.Logf("rig: service %q failed: %s", ev.Service, ev.Error)
+
+	case "artifact.started":
+		t.Logf("rig: resolving artifact %q", ev.Artifact)
+
+	case "artifact.cached":
+		t.Logf("rig: artifact %q (cached)", ev.Artifact)
+
+	case "artifact.completed":
+		t.Logf("rig: artifact %q resolved", ev.Artifact)
+
+	case "artifact.failed":
+		t.Logf("rig: artifact %q failed: %s", ev.Artifact, ev.Error)
+	}
+
+	return nil, false, nil
+}
+
+// dispatchCallback finds the registered handler, calls it, and POSTs the result.
+func dispatchCallback(
+	ctx context.Context,
+	serverURL string,
+	envID string,
+	cb *wireCallbackRequest,
+	handlers map[string]hookFunc,
+) error {
+	handler, ok := handlers[cb.Name]
+	if !ok {
+		// Post error back so the server lifecycle doesn't hang forever.
+		postCallbackResult(serverURL, envID, cb.RequestID,
+			fmt.Errorf("no handler registered for callback %q", cb.Name))
+		return fmt.Errorf("no handler registered for callback %q", cb.Name)
+	}
+
+	wiring := convertWiring(cb.Wiring)
+
+	var handlerErr error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				handlerErr = fmt.Errorf("panic in hook handler: %v", r)
+			}
+		}()
+		handlerErr = handler(ctx, wiring)
+	}()
+
+	if err := postCallbackResult(serverURL, envID, cb.RequestID, handlerErr); err != nil {
+		return err
+	}
+	return handlerErr
+}
+
+// postCallbackResult POSTs the callback response to the server.
+func postCallbackResult(serverURL, envID, requestID string, handlerErr error) error {
+	payload := wireCallbackResponse{RequestID: requestID}
+	if handlerErr != nil {
+		payload.Error = handlerErr.Error()
+	}
+
+	body, _ := json.Marshal(payload)
+	url := fmt.Sprintf("%s/environments/%s/callbacks/%s", serverURL, envID, requestID)
+
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("post callback result: %w", err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// convertWiring converts wire format wiring to SDK Wiring type.
+func convertWiring(w *wireWiringContext) Wiring {
+	if w == nil {
+		return Wiring{}
+	}
+	return Wiring{
+		Ingresses:  convertEndpoints(w.Ingresses),
+		Egresses:   convertEndpoints(w.Egresses),
+		Attributes: w.Attributes,
+		TempDir:    w.TempDir,
+		EnvDir:     w.EnvDir,
+	}
+}
+
+// convertEndpoints converts wireEndpoint maps to SDK Endpoint maps.
+func convertEndpoints(eps map[string]wireEndpoint) map[string]Endpoint {
+	if eps == nil {
+		return nil
+	}
+	out := make(map[string]Endpoint, len(eps))
+	for name, ep := range eps {
+		out[name] = Endpoint{
+			Host:       ep.Host,
+			Port:       ep.Port,
+			Protocol:   ep.Protocol,
+			Attributes: ep.Attributes,
+		}
+	}
+	return out
+}
+
+// buildEnvironmentFromEvent constructs an Environment from an environment.up event.
+func buildEnvironmentFromEvent(ev wireEvent) *Environment {
+	services := make(map[string]ResolvedService, len(ev.Ingresses))
+	for svcName, ingressMap := range ev.Ingresses {
+		ingresses := make(map[string]Endpoint, len(ingressMap))
+		for ingName, ep := range ingressMap {
+			ingresses[ingName] = Endpoint{
+				Host:       ep.Host,
+				Port:       ep.Port,
+				Protocol:   ep.Protocol,
+				Attributes: ep.Attributes,
+			}
+		}
+		services[svcName] = ResolvedService{Ingresses: ingresses}
+	}
+	return &Environment{
+		Services: services,
+	}
+}

--- a/connect/endpoint.go
+++ b/connect/endpoint.go
@@ -1,0 +1,40 @@
+// Package connect defines shared types for rig service endpoints and wiring.
+//
+// These types are used by the rig SDK (client/) and by connect packages
+// (httpx/, etc.). Service runtime code can also use these types directly
+// without depending on the full rig SDK.
+package connect
+
+import "fmt"
+
+// Protocol identifies the application-layer protocol an endpoint speaks.
+type Protocol string
+
+const (
+	TCP  Protocol = "tcp"
+	HTTP Protocol = "http"
+	GRPC Protocol = "grpc"
+)
+
+// Endpoint is a resolved service endpoint with connection helpers.
+type Endpoint struct {
+	Host       string         `json:"host"`
+	Port       int            `json:"port"`
+	Protocol   Protocol       `json:"protocol"`
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// Addr returns "host:port" suitable for net.Dial, grpc.Dial, etc.
+func (e Endpoint) Addr() string {
+	return fmt.Sprintf("%s:%d", e.Host, e.Port)
+}
+
+// Attr returns the value of a named attribute as a string. Returns "" if
+// the attribute is not found.
+func (e Endpoint) Attr(name string) string {
+	v, ok := e.Attributes[name]
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/connect/go.mod
+++ b/connect/go.mod
@@ -1,0 +1,3 @@
+module github.com/matgreaves/rig/connect
+
+go 1.25.5

--- a/connect/httpx/client.go
+++ b/connect/httpx/client.go
@@ -1,0 +1,76 @@
+// Package httpx provides an HTTP client and server built on rig endpoints.
+//
+// In tests, construct from a resolved environment endpoint:
+//
+//	client := httpx.New(env.Endpoint("api"))
+//	resp, err := client.Get("/health")
+//
+// In service code, construct from parsed wiring:
+//
+//	w, _ := connect.ParseWiring(ctx)
+//	client := httpx.New(w.Egress("api"))
+package httpx
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/matgreaves/rig/connect"
+)
+
+// Client is an HTTP client that prepends a base URL to all request paths.
+type Client struct {
+	// BaseURL is prepended to all request paths (e.g. "http://127.0.0.1:8080").
+	// Must not have a trailing slash.
+	BaseURL string
+
+	// HTTP is the underlying http.Client. If nil, http.DefaultClient is used.
+	HTTP *http.Client
+}
+
+// New creates an HTTP client from a resolved endpoint.
+func New(ep connect.Endpoint) *Client {
+	return &Client{BaseURL: "http://" + ep.Addr()}
+}
+
+// NewClient creates an HTTP client for the given base URL string.
+func NewClient(baseURL string) *Client {
+	return &Client{BaseURL: baseURL}
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return http.DefaultClient
+}
+
+// Get sends a GET request to BaseURL + path.
+func (c *Client) Get(path string) (*http.Response, error) {
+	return c.httpClient().Get(c.BaseURL + path)
+}
+
+// Head sends a HEAD request to BaseURL + path.
+func (c *Client) Head(path string) (*http.Response, error) {
+	return c.httpClient().Head(c.BaseURL + path)
+}
+
+// Post sends a POST request to BaseURL + path.
+func (c *Client) Post(path, contentType string, body io.Reader) (*http.Response, error) {
+	return c.httpClient().Post(c.BaseURL+path, contentType, body)
+}
+
+// Do sends an HTTP request. If the request URL has no host (i.e. is a
+// relative path like "/orders/1"), it is resolved against BaseURL.
+// Absolute URLs are sent as-is.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if req.URL.Host == "" {
+		base, err := url.Parse(c.BaseURL)
+		if err != nil {
+			return nil, err
+		}
+		req.URL = base.ResolveReference(req.URL)
+	}
+	return c.httpClient().Do(req)
+}

--- a/connect/httpx/client_test.go
+++ b/connect/httpx/client_test.go
@@ -1,0 +1,163 @@
+package httpx_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/matgreaves/rig/connect/httpx"
+)
+
+func TestGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/health" {
+			t.Errorf("path = %s, want /health", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := httpx.NewClient(ts.URL)
+	resp, err := client.Get("/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHead(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "HEAD" {
+			t.Errorf("method = %s, want HEAD", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := httpx.NewClient(ts.URL)
+	resp, err := client.Head("/ping")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestPost(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/orders" {
+			t.Errorf("path = %s, want /orders", r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("content-type = %s, want application/json", ct)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != `{"id":1}` {
+			t.Errorf("body = %s, want {\"id\":1}", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer ts.Close()
+
+	client := httpx.NewClient(ts.URL)
+	resp, err := client.Post("/orders", "application/json", bytes.NewBufferString(`{"id":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("status = %d, want 201", resp.StatusCode)
+	}
+}
+
+func TestDo_RelativePath(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/orders/42" {
+			t.Errorf("path = %s, want /orders/42", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	client := httpx.NewClient(ts.URL)
+	req, _ := http.NewRequest("DELETE", "/orders/42", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", resp.StatusCode)
+	}
+}
+
+func TestDo_AbsoluteURL(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Client pointed at a different base URL.
+	client := httpx.NewClient("http://should-not-be-used:9999")
+	// Absolute URL overrides BaseURL.
+	req, _ := http.NewRequest("GET", ts.URL+"/override", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestCustomHTTPClient(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "test" {
+			t.Error("custom transport header missing")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := httpx.NewClient(ts.URL)
+	client.HTTP = &http.Client{
+		Transport: &headerTransport{Header: "X-Custom", Value: "test"},
+	}
+
+	resp, err := client.Get("/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// headerTransport is a test RoundTripper that injects a header.
+type headerTransport struct {
+	Header string
+	Value  string
+}
+
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(t.Header, t.Value)
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/connect/httpx/server.go
+++ b/connect/httpx/server.go
@@ -1,0 +1,55 @@
+package httpx
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/matgreaves/rig/connect"
+)
+
+// ListenAndServe reads the default ingress endpoint from the environment
+// and starts an HTTP server with the given handler. It blocks until ctx
+// is cancelled, then shuts down gracefully.
+//
+// This is the server-side counterpart to New / NewClient.
+//
+//	func main() {
+//	    ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+//	    defer stop()
+//	    mux := http.NewServeMux()
+//	    mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+//	    httpx.ListenAndServe(ctx, mux)
+//	}
+func ListenAndServe(ctx context.Context, handler http.Handler) error {
+	w, err := connect.ParseWiring(ctx)
+	if err != nil {
+		return err
+	}
+	return Serve(ctx, w.Ingress(), handler)
+}
+
+// Serve starts an HTTP server on the given endpoint with the provided
+// handler. It blocks until ctx is cancelled, then shuts down gracefully
+// with a 5-second timeout.
+func Serve(ctx context.Context, ep connect.Endpoint, handler http.Handler) error {
+	srv := &http.Server{
+		Addr:    ep.Addr(),
+		Handler: handler,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe()
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return srv.Shutdown(shutdownCtx)
+}

--- a/connect/wiring.go
+++ b/connect/wiring.go
@@ -1,0 +1,86 @@
+package connect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+)
+
+// Wiring provides resolved endpoint information to services and hook
+// functions. Use ParseWiring to read from the environment.
+type Wiring struct {
+	Ingresses  map[string]Endpoint `json:"ingresses,omitempty"`
+	Egresses   map[string]Endpoint `json:"egresses,omitempty"`
+	Attributes map[string]string   `json:"attributes,omitempty"`
+	TempDir    string              `json:"temp_dir,omitempty"`
+	EnvDir     string              `json:"env_dir,omitempty"`
+}
+
+// Ingress returns the named ingress endpoint. If no name is provided,
+// "default" is used. Panics with a descriptive message if not found.
+func (w *Wiring) Ingress(name ...string) Endpoint {
+	n := "default"
+	if len(name) > 0 {
+		n = name[0]
+	}
+	ep, ok := w.Ingresses[n]
+	if !ok {
+		panic(fmt.Sprintf("rig: ingress %q not found in wiring (available: %s)",
+			n, sortedMapKeys(w.Ingresses)))
+	}
+	return ep
+}
+
+// Egress returns the named egress endpoint.
+// Panics with a descriptive message if not found.
+func (w *Wiring) Egress(name string) Endpoint {
+	ep, ok := w.Egresses[name]
+	if !ok {
+		panic(fmt.Sprintf("rig: egress %q not found in wiring (available: %s)",
+			name, sortedMapKeys(w.Egresses)))
+	}
+	return ep
+}
+
+// ParseWiring reads the service wiring from the environment. It parses
+// RIG_WIRING if set, falling back to HOST/PORT for standalone use.
+//
+// The ctx parameter is reserved for future use (e.g. wiring passed
+// through context in function runners).
+func ParseWiring(_ context.Context) (*Wiring, error) {
+	if raw := os.Getenv("RIG_WIRING"); raw != "" {
+		var w Wiring
+		if err := json.Unmarshal([]byte(raw), &w); err != nil {
+			return nil, fmt.Errorf("parse RIG_WIRING: %w", err)
+		}
+		return &w, nil
+	}
+
+	// Fallback: construct minimal wiring from HOST/PORT.
+	host := os.Getenv("HOST")
+	portStr := os.Getenv("PORT")
+	if host == "" || portStr == "" {
+		return nil, fmt.Errorf("HOST and PORT must be set (or RIG_WIRING)")
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PORT %q: %w", portStr, err)
+	}
+	return &Wiring{
+		Ingresses: map[string]Endpoint{
+			"default": {Host: host, Port: port},
+		},
+	}, nil
+}
+
+func sortedMapKeys[V any](m map[string]V) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("%v", keys)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/matgreaves/rig
 
 go 1.25.5
 
-require github.com/matgreaves/run v0.0.0-20260218110328-eb38e0ac8e05
+require (
+	github.com/matgreaves/rig/connect v0.0.0
+	github.com/matgreaves/run v0.0.0-20260218110328-eb38e0ac8e05
+)
 
 require al.essio.dev/pkg/shellescape v1.6.0 // indirect
+
+replace github.com/matgreaves/rig/connect => ./connect

--- a/testdata/services/echo/main.go
+++ b/testdata/services/echo/main.go
@@ -1,101 +1,32 @@
 // echo is a minimal HTTP server used for integration tests.
-// It demonstrates the preferred pattern for rig-aware services:
-// parse RIG_WIRING once at startup, pass typed config through to functions.
 package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
-	"time"
 
-	"github.com/matgreaves/rig/spec"
+	"github.com/matgreaves/rig/connect/httpx"
 )
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
-	if err := run(ctx, os.Args[1:]); err != nil {
+	if err := run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "echo: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, _ []string) error {
-	ep, err := ingressEndpoint()
-	if err != nil {
-		return err
-	}
-	return serve(ctx, ep)
-}
-
-func serve(ctx context.Context, ep spec.Endpoint) error {
+func run(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "echo: %s %s", r.Method, r.URL.Path)
 	})
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "ok")
 	})
-
-	srv := &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", ep.Host, ep.Port),
-		Handler: mux,
-	}
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- srv.ListenAndServe()
-	}()
-
-	select {
-	case err := <-errCh:
-		return err
-	case <-ctx.Done():
-	}
-
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	return srv.Shutdown(shutdownCtx)
-}
-
-// ingressEndpoint resolves an ingress endpoint from the environment.
-// Defaults to the "default" ingress; pass a name to select another.
-// Prefers RIG_WIRING (structured JSON) over the flat HOST/PORT env vars.
-// In real code, use the rig client library instead of inlining this.
-func ingressEndpoint(name ...string) (spec.Endpoint, error) {
-	n := "default"
-	if len(name) > 0 {
-		n = name[0]
-	}
-	if raw := os.Getenv("RIG_WIRING"); raw != "" {
-		var w struct {
-			Ingresses map[string]spec.Endpoint `json:"ingresses"`
-		}
-		if err := json.Unmarshal([]byte(raw), &w); err != nil {
-			return spec.Endpoint{}, fmt.Errorf("parse RIG_WIRING: %w", err)
-		}
-		ep, ok := w.Ingresses[n]
-		if !ok {
-			return spec.Endpoint{}, fmt.Errorf("RIG_WIRING: no ingress %q", n)
-		}
-		return ep, nil
-	}
-
-	// Fallback for non-rig-aware callers.
-	host := os.Getenv("HOST")
-	portStr := os.Getenv("PORT")
-	if host == "" || portStr == "" {
-		return spec.Endpoint{}, fmt.Errorf("HOST and PORT must be set (or RIG_WIRING)")
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return spec.Endpoint{}, fmt.Errorf("invalid PORT %q: %w", portStr, err)
-	}
-	return spec.Endpoint{Host: host, Port: port}, nil
+	return httpx.ListenAndServe(ctx, mux)
 }

--- a/testdata/services/tcpecho/main.go
+++ b/testdata/services/tcpecho/main.go
@@ -1,47 +1,40 @@
 // tcpecho is a minimal TCP echo server for integration tests.
-// It demonstrates the preferred pattern for rig-aware services:
-// parse RIG_WIRING once at startup, pass typed config through to functions.
 package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"os/signal"
-	"strconv"
 
-	"github.com/matgreaves/rig/spec"
+	"github.com/matgreaves/rig/connect"
 )
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
-	if err := run(ctx, os.Args[1:]); err != nil {
+	if err := run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "tcpecho: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, _ []string) error {
-	ep, err := ingressEndpoint()
+func run(ctx context.Context) error {
+	w, err := connect.ParseWiring(ctx)
 	if err != nil {
 		return err
 	}
-	return serve(ctx, ep)
-}
+	ep := w.Ingress()
 
-func serve(ctx context.Context, ep spec.Endpoint) error {
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", ep.Host, ep.Port))
+	ln, err := net.Listen("tcp", ep.Addr())
 	if err != nil {
 		return fmt.Errorf("listen: %w", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "tcpecho: listening on %s:%d\n", ep.Host, ep.Port)
+	fmt.Fprintf(os.Stdout, "tcpecho: listening on %s\n", ep.Addr())
 
-	// Close listener when context is cancelled to unblock Accept.
 	go func() {
 		<-ctx.Done()
 		ln.Close()
@@ -51,7 +44,7 @@ func serve(ctx context.Context, ep spec.Endpoint) error {
 		conn, err := ln.Accept()
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil // clean shutdown
+				return nil
 			}
 			return err
 		}
@@ -60,40 +53,4 @@ func serve(ctx context.Context, ep spec.Endpoint) error {
 			io.Copy(conn, conn)
 		}()
 	}
-}
-
-// ingressEndpoint resolves an ingress endpoint from the environment.
-// Defaults to the "default" ingress; pass a name to select another.
-// Prefers RIG_WIRING (structured JSON) over the flat HOST/PORT env vars.
-// In real code, use the rig client library instead of inlining this.
-func ingressEndpoint(name ...string) (spec.Endpoint, error) {
-	n := "default"
-	if len(name) > 0 {
-		n = name[0]
-	}
-	if raw := os.Getenv("RIG_WIRING"); raw != "" {
-		var w struct {
-			Ingresses map[string]spec.Endpoint `json:"ingresses"`
-		}
-		if err := json.Unmarshal([]byte(raw), &w); err != nil {
-			return spec.Endpoint{}, fmt.Errorf("parse RIG_WIRING: %w", err)
-		}
-		ep, ok := w.Ingresses[n]
-		if !ok {
-			return spec.Endpoint{}, fmt.Errorf("RIG_WIRING: no ingress %q", n)
-		}
-		return ep, nil
-	}
-
-	// Fallback for non-rig-aware callers.
-	host := os.Getenv("HOST")
-	portStr := os.Getenv("PORT")
-	if host == "" || portStr == "" {
-		return spec.Endpoint{}, fmt.Errorf("HOST and PORT must be set (or RIG_WIRING)")
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return spec.Endpoint{}, fmt.Errorf("invalid PORT %q: %w", portStr, err)
-	}
-	return spec.Endpoint{Host: host, Port: port}, nil
 }


### PR DESCRIPTION
Add the Go client SDK (client/) and shared connect module (connect/) that together provide the primary user-facing API for defining and interacting with rig test environments.

SDK (client/):
- rig.Up(t, services, opts...) creates environments, blocks until ready, and registers t.Cleanup for teardown
- Fluent service builders: rig.Go(), rig.Process(), rig.Custom() all default to a single HTTP ingress with chaining methods for Ingress(), NoIngress(), Egress(), EgressAs(), Args(), InitHook(), PrestartHook()
- Environment.Endpoint() lookups with single-ingress shorthand and descriptive panic-on-miss messages
- SSE event stream processing with callback dispatch for client-side hooks (init and prestart)
- Spec conversion layer translates SDK types to wire format with automatic path resolution and hook name generation

Connect module (connect/):
- Separate Go module (connect/go.mod) so service runtime code can import shared types without depending on the test SDK or server
- connect.Endpoint with Addr() and Attr() helpers
- connect.ParseWiring(ctx) parses RIG_WIRING env var (or HOST/PORT fallback) once, with Ingress()/Egress() lookups on the result
- connect/httpx: HTTP client (New/NewClient) with base URL prepending, and context-aware server (ListenAndServe/Serve) with graceful shutdown

Testdata services simplified:
- echo: ~100 lines → ~30 lines using httpx.ListenAndServe
- tcpecho: ~90 lines → ~55 lines using connect.ParseWiring