### PR TITLE
rig.Func(): client-side function services

### DIFF
--- a/server/artifact/gobuild_test.go
+++ b/server/artifact/gobuild_test.go
@@ -34,7 +34,7 @@ func moduleRoot(t *testing.T) string {
 
 func TestGoBuild_CacheKey_Stable(t *testing.T) {
 	root := moduleRoot(t)
-	echoDir := filepath.Join(root, "testdata", "services", "echo")
+	echoDir := filepath.Join(root, "testdata", "services", "echo", "cmd")
 
 	g := artifact.GoBuild{Module: echoDir}
 
@@ -91,7 +91,7 @@ func TestGoBuild_CacheKey_Changes(t *testing.T) {
 
 func TestGoBuild_Resolve(t *testing.T) {
 	root := moduleRoot(t)
-	echoDir := filepath.Join(root, "testdata", "services", "echo")
+	echoDir := filepath.Join(root, "testdata", "services", "echo", "cmd")
 
 	g := artifact.GoBuild{Module: echoDir}
 	outputDir := t.TempDir()

--- a/server/orchestrator_test.go
+++ b/server/orchestrator_test.go
@@ -62,7 +62,7 @@ func newTestOrchestrator(t *testing.T) *server.Orchestrator {
 }
 
 func TestOrchestrate_SingleHTTPService(t *testing.T) {
-	echoBin := buildTestBinary(t, "testdata/services/echo")
+	echoBin := buildTestBinary(t, "testdata/services/echo/cmd")
 
 	orch := newTestOrchestrator(t)
 
@@ -144,7 +144,7 @@ func TestOrchestrate_SingleHTTPService(t *testing.T) {
 }
 
 func TestOrchestrate_DependencyOrdering(t *testing.T) {
-	echoBin := buildTestBinary(t, "testdata/services/echo")
+	echoBin := buildTestBinary(t, "testdata/services/echo/cmd")
 	tcpBin := buildTestBinary(t, "testdata/services/tcpecho")
 
 	orch := newTestOrchestrator(t)
@@ -226,7 +226,7 @@ func TestOrchestrate_DependencyOrdering(t *testing.T) {
 
 func TestOrchestrate_NoIngressService(t *testing.T) {
 	// A service with no ingresses should start and become ready without health checks.
-	echoBin := buildTestBinary(t, "testdata/services/echo")
+	echoBin := buildTestBinary(t, "testdata/services/echo/cmd")
 
 	orch := newTestOrchestrator(t)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -160,7 +160,7 @@ func TestServer_ValidationErrors(t *testing.T) {
 }
 
 func TestServer_CreateAndStream(t *testing.T) {
-	echoBin := buildTestBinary(t, "testdata/services/echo")
+	echoBin := buildTestBinary(t, "testdata/services/echo/cmd")
 	ts := newTestServer(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -240,7 +240,7 @@ func TestServer_CreateAndStream(t *testing.T) {
 }
 
 func TestServer_GetEnvironment(t *testing.T) {
-	echoBin := buildTestBinary(t, "testdata/services/echo")
+	echoBin := buildTestBinary(t, "testdata/services/echo/cmd")
 	ts := newTestServer(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -365,7 +365,7 @@ func TestServer_FailurePropagation(t *testing.T) {
 }
 
 func TestServer_ConcurrentDelete(t *testing.T) {
-	echoBin := buildTestBinary(t, "testdata/services/echo")
+	echoBin := buildTestBinary(t, "testdata/services/echo/cmd")
 	ts := newTestServer(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -453,7 +453,7 @@ func TestServer_IdleTimer(t *testing.T) {
 
 func TestServer_GoServiceType(t *testing.T) {
 	root := moduleRoot(t)
-	echoModule := filepath.Join(root, "testdata", "services", "echo")
+	echoModule := filepath.Join(root, "testdata", "services", "echo", "cmd")
 
 	cacheDir := t.TempDir()
 

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/matgreaves/rig/spec"
+	"github.com/matgreaves/run"
+)
+
+// ClientConfig is the type-specific config for "client" services.
+type ClientConfig struct {
+	// StartHandler is the name of the client-side start callback.
+	StartHandler string `json:"start_handler"`
+}
+
+// Client implements Type for the "client" service type. A client service
+// delegates its start phase to a function in the client SDK via the callback
+// protocol. The server allocates ports and health-checks normally; only the
+// "start" step is handled client-side.
+type Client struct{}
+
+// Publish resolves ingress endpoints for a client service.
+// Client services run locally, so they use the standard local publish.
+func (Client) Publish(_ context.Context, params PublishParams) (map[string]spec.Endpoint, error) {
+	return PublishLocalEndpoints(params)
+}
+
+// Runner returns a runner that dispatches a start callback to the client,
+// then idles until ctx is cancelled.
+func (Client) Runner(params StartParams) run.Runner {
+	var cfg ClientConfig
+	if params.Spec.Config != nil {
+		if err := json.Unmarshal(params.Spec.Config, &cfg); err != nil {
+			return run.Func(func(context.Context) error {
+				return fmt.Errorf("service %q: invalid client config: %w", params.ServiceName, err)
+			})
+		}
+	}
+
+	if params.Callback == nil {
+		return run.Func(func(context.Context) error {
+			return fmt.Errorf("service %q: client type requires callback support", params.ServiceName)
+		})
+	}
+
+	return run.Func(func(ctx context.Context) error {
+		// Dispatch the start callback — the client launches the function
+		// and responds immediately. The function runs until its context
+		// is cancelled during cleanup.
+		if err := params.Callback(ctx, cfg.StartHandler, "start"); err != nil {
+			return fmt.Errorf("service %q: start callback: %w", params.ServiceName, err)
+		}
+
+		// Idle until teardown. The service function is running in the
+		// client process; health checks will validate it's ready.
+		<-ctx.Done()
+		return ctx.Err()
+	})
+}

--- a/server/service/type.go
+++ b/server/service/type.go
@@ -31,6 +31,10 @@ type StartParams struct {
 	EnvDir      string
 	Stdout      io.Writer
 	Stderr      io.Writer
+
+	// Callback dispatches a callback request to the client SDK and blocks
+	// until the response arrives. Nil for types that don't use callbacks.
+	Callback func(ctx context.Context, name, callbackType string) error
 }
 
 // ArtifactParams is passed to ArtifactProvider.Artifacts.

--- a/server/validate.go
+++ b/server/validate.go
@@ -15,6 +15,7 @@ var KnownServiceTypes = map[string]bool{
 	"process":   true,
 	"script":    true,
 	"go":        true,
+	"client":    true,
 	"postgres":  true,
 	"temporal":  true,
 	"redis":     true,

--- a/testdata/services/echo/cmd/main.go
+++ b/testdata/services/echo/cmd/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/matgreaves/rig/testdata/services/echo"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	if err := echo.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "echo: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/testdata/services/echo/echo.go
+++ b/testdata/services/echo/echo.go
@@ -1,26 +1,20 @@
-// echo is a minimal HTTP server used for integration tests.
-package main
+// Package echo is a minimal HTTP echo server for integration tests.
+//
+// It can be used as a standalone binary via the cmd/ subdirectory,
+// or in-process via rig.Func(echo.Run).
+package echo
 
 import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"os/signal"
 
 	"github.com/matgreaves/rig/connect/httpx"
 )
 
-func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer stop()
-	if err := run(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "echo: %v\n", err)
-		os.Exit(1)
-	}
-}
-
-func run(ctx context.Context) error {
+// Run starts the echo HTTP server. It reads wiring from ctx (via
+// connect.ParseWiring) and blocks until ctx is cancelled.
+func Run(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "echo: %s %s", r.Method, r.URL.Path)


### PR DESCRIPTION
Add rig.Func() — a service type where a user-provided Go function runs in the test process, wired like any other service. The same function works as both rig.Func(echo.Run) and rig.Go("echo/cmd") because connect.ParseWiring(ctx) checks context before environment variables.

Server:
- New "client" service type that delegates start via the callback protocol
- Callback field on StartParams for service types that need it
- Extract dispatchCallback from executeHook for reuse by both hooks and start callbacks
- Unified POST /environments/{id}/events endpoint replaces the per-callback URL, handling both callback.response and service.error event types

Client SDK:
- FuncDef with full builder API (Ingress, Egress, InitHook, PrestartHook)
- Async start dispatch: function launched in goroutine with wiring injected into context via connect.WithWiring, callback response sent immediately
- funcCtx lifecycle: created in Up(), cancelled in t.Cleanup before DELETE
- Error reporting: if a Func service crashes before cleanup, a service.error event is posted to the server for proper diagnostics

Connect:
- WithWiring(ctx, *Wiring) injects wiring into context
- ParseWiring(ctx) checks context first, then RIG_WIRING, then HOST/PORT

Testdata:
- Refactor echo service into importable package (echo.Run) + cmd/ binary
- Update all test paths from echo/ to echo/cmd