### PR TITLE
Diagnostics: event log files, test assertion capture, and teardown events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.rig-test-cache/
+.rig/

--- a/client/environment.go
+++ b/client/environment.go
@@ -3,6 +3,7 @@ package rig
 import (
 	"fmt"
 	"sort"
+	"testing"
 )
 
 // Environment is the resolved, running environment returned by Up.
@@ -11,6 +12,13 @@ type Environment struct {
 	ID       string
 	Name     string
 	Services map[string]ResolvedService
+
+	// T is a wrapped testing.TB that automatically captures assertion
+	// failures (Fatal, Fatalf, Error, Errorf) as test.note events in
+	// the rig event log. Pass env.T to assertion libraries (testify,
+	// is, require, etc.) so failures appear in the event timeline
+	// alongside server-side events. File:line reporting is preserved.
+	T testing.TB
 }
 
 // ResolvedService holds the resolved endpoints for a single service.

--- a/client/tb.go
+++ b/client/tb.go
@@ -1,0 +1,64 @@
+package rig
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// rigTB wraps a testing.TB to intercept assertion failures and post them
+// as test.note events to the rig server's event log. This creates a unified
+// timeline of server-side events and client-side test assertions.
+//
+// Helper() is NOT overridden — calls pass through to the embedded TB,
+// preserving correct file:line reporting even when assertion libraries
+// (testify, is, require, etc.) call t.Helper() internally.
+type rigTB struct {
+	testing.TB
+	serverURL string
+	envID     string
+}
+
+func (tb *rigTB) Error(args ...any) {
+	tb.Helper()
+	msg := fmt.Sprint(args...)
+	tb.postNote(msg)
+	tb.TB.Error(args...)
+}
+
+func (tb *rigTB) Errorf(format string, args ...any) {
+	tb.Helper()
+	msg := fmt.Sprintf(format, args...)
+	tb.postNote(msg)
+	tb.TB.Errorf(format, args...)
+}
+
+func (tb *rigTB) Fatal(args ...any) {
+	tb.Helper()
+	msg := fmt.Sprint(args...)
+	tb.postNote(msg)
+	tb.TB.Fatal(args...)
+}
+
+func (tb *rigTB) Fatalf(format string, args ...any) {
+	tb.Helper()
+	msg := fmt.Sprintf(format, args...)
+	tb.postNote(msg)
+	tb.TB.Fatalf(format, args...)
+}
+
+func (tb *rigTB) postNote(msg string) {
+	// Capture the caller's file:line. Skip postNote (0) and the
+	// Error/Errorf/Fatal/Fatalf wrapper (1) to reach the call site.
+	if _, file, line, ok := runtime.Caller(2); ok {
+		msg = fmt.Sprintf("%s:%d: %s", filepath.Base(file), line, msg)
+	}
+	postClientEvent(tb.serverURL, tb.envID, struct {
+		Type  string `json:"type"`
+		Error string `json:"error"`
+	}{
+		Type:  "test.note",
+		Error: msg,
+	})
+}

--- a/server/artifact/gobuild.go
+++ b/server/artifact/gobuild.go
@@ -81,7 +81,7 @@ func (g GoBuild) localCacheKey() (string, error) {
 		}
 	}
 
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return "go/" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func (g GoBuild) remoteCacheKey() (string, error) {
@@ -91,7 +91,7 @@ func (g GoBuild) remoteCacheKey() (string, error) {
 	// The module reference is the version pin; no file hashing needed.
 	raw := fmt.Sprintf("goos:%s\ngoarch:%s\ngoversion:%s\nmodule:%s", g.goos(), g.goarch(), runtime.Version(), g.Module)
 	sum := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(sum[:]), nil
+	return "go/" + hex.EncodeToString(sum[:]), nil
 }
 
 // Cached checks whether a compiled binary exists in outputDir from a previous

--- a/server/eventlog.go
+++ b/server/eventlog.go
@@ -36,8 +36,12 @@ const (
 	EventCallbackResponse EventType = "callback.response"
 
 	// Environment lifecycle.
-	EventEnvironmentUp   EventType = "environment.up"
-	EventEnvironmentDown EventType = "environment.down"
+	EventEnvironmentDestroying EventType = "environment.destroying"
+	EventEnvironmentUp         EventType = "environment.up"
+	EventEnvironmentDown       EventType = "environment.down"
+
+	// Client-side test events.
+	EventTestNote EventType = "test.note"
 )
 
 // LogEntry holds a line of service output.

--- a/server/orchestrator.go
+++ b/server/orchestrator.go
@@ -143,12 +143,20 @@ func (o *Orchestrator) cacheDir() string {
 	if o.CacheDir != "" {
 		return o.CacheDir
 	}
+	return filepath.Join(DefaultRigDir(), "cache")
+}
+
+// DefaultRigDir returns the base rig directory. It checks RIG_DIR first,
+// then falls back to ~/.rig, then $TMPDIR/rig.
+func DefaultRigDir() string {
+	if dir := os.Getenv("RIG_DIR"); dir != "" {
+		return dir
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		// Fallback to a temp-dir-adjacent location if home is unavailable.
-		return filepath.Join(os.TempDir(), "rig-cache")
+		return filepath.Join(os.TempDir(), "rig")
 	}
-	return filepath.Join(home, ".rig", "cache")
+	return filepath.Join(home, ".rig")
 }
 
 func sortedServiceNames(services map[string]spec.Service) []string {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -29,7 +29,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 		reg,
 		t.TempDir(),
 		0,           // idle timeout disabled
-		t.TempDir(), // isolated artifact cache
+		t.TempDir(), // isolated rig dir
 	)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)


### PR DESCRIPTION
When a test fails, rig now writes two files to .rig/logs/ and prints the path:

  rig: event log written to .rig/logs/TestMyService-88436435a6e81ca1.jsonl

  The .jsonl file is the full structured event log (one event per line) for tooling. The .log file is a human-readable timeline for quick scanning:

```
  rig: event timeline for environment 88436435a6e81ca1:
     0.00s  artifact.started       gobuild:.../testdata/services/fail
     0.18s  artifact.completed     gobuild:.../testdata/services/fail
     0.18s  ingress.published      api
     0.18s  ingress.published      broken
     0.18s  service.starting       broken
     0.43s  service.failed         broken       exit status 1
            | connecting to database at localhost:5432
            | connection refused: dial tcp 127.0.0.1:5432: connect: connection refused
            | retrying (1/3)...
            | connection refused: dial tcp 127.0.0.1:5432: connect: connection refused
            | fail: database unavailable after 3 retries
     0.43s  service.stopped        broken
     0.43s  service.stopping       api
     0.43s  service.stopped        api
     0.43s  environment.down
```

  Changes

  Unified .rig/ directory — Cache and logs now live under a single .rig/ directory (cache/ + logs/), controlled by RIG_DIR env var. Cache keys are prefixed by resolver type (e.g.
  .rig/cache/go/{hash}).

  Test assertion capture — env.T wraps testing.TB to intercept Error/Errorf/Fatal/Fatalf, posting test.note events with file:line to the server event log. Test assertions appear inline in
  the timeline alongside service lifecycle events.

  Server-side log writing — On DELETE ?log=true (sent automatically when t.Failed()), the server writes both files to disk and returns the path. No log data transferred over HTTP on the
  happy path.

  Failed service log tail — The timeline includes the last 10 lines of stdout/stderr for any service that failed, shown with | prefix after the service.failed event.

  Teardown events — New service.stopping, service.stopped, and environment.destroying events capture the full teardown lifecycle. service.failed is now emitted for server-side process
  crashes (previously only client-side service.error events set this). environment.destroying is skipped when a crash already brought the environment down.

  Timeline filtering — service.log events (per-line stdout/stderr) are excluded from the timeline since it's a structural overview. Full output is in the JSONL.