### PR TITLE
Diagnostics: transparent traffic proxy and health check improvements

### DIFF
--- a/client/convert.go
+++ b/client/convert.go
@@ -16,7 +16,7 @@ var hookSeq atomic.Uint64
 // envToSpec converts the SDK Services to the spec.Environment wire format.
 // Hook functions are registered in handlers keyed by their generated name.
 // Start functions (from FuncDef) are registered in startHandlers.
-func envToSpec(testName string, services Services, handlers map[string]hookFunc, startHandlers map[string]startFunc) (spec.Environment, error) {
+func envToSpec(testName string, services Services, handlers map[string]hookFunc, startHandlers map[string]startFunc, observe bool) (spec.Environment, error) {
 	specs := make(map[string]spec.Service, len(services))
 	for name, def := range services {
 		svc, err := serviceToSpec(def, handlers, startHandlers)
@@ -28,6 +28,7 @@ func envToSpec(testName string, services Services, handlers map[string]hookFunc,
 	return spec.Environment{
 		Name:     testName,
 		Services: specs,
+		Observe:  observe,
 	}, nil
 }
 

--- a/server/eventlog.go
+++ b/server/eventlog.go
@@ -42,6 +42,15 @@ const (
 
 	// Client-side test events.
 	EventTestNote EventType = "test.note"
+
+	// Health checks.
+	EventHealthCheckFailed EventType = "health.check_failed"
+
+	// Traffic observation.
+	EventRequestCompleted  EventType = "request.completed"
+	EventConnectionOpened  EventType = "connection.opened"
+	EventConnectionClosed  EventType = "connection.closed"
+	EventProxyPublished    EventType = "proxy.published"
 )
 
 // LogEntry holds a line of service output.
@@ -79,6 +88,36 @@ type CallbackResponse struct {
 	Data      map[string]any `json:"data,omitempty"`
 }
 
+// RequestInfo captures an observed HTTP request/response pair.
+type RequestInfo struct {
+	Source       string  `json:"source"`
+	Target       string  `json:"target"`
+	Ingress      string  `json:"ingress"`
+	Method       string  `json:"method"`
+	Path         string  `json:"path"`
+	StatusCode   int     `json:"status_code"`
+	LatencyMs    float64 `json:"latency_ms"`
+	RequestSize  int64   `json:"request_size"`
+	ResponseSize int64   `json:"response_size"`
+
+	RequestHeaders        map[string][]string `json:"request_headers,omitempty"`
+	RequestBody           []byte              `json:"request_body,omitempty"`
+	RequestBodyTruncated  bool                `json:"request_body_truncated,omitempty"`
+	ResponseHeaders       map[string][]string `json:"response_headers,omitempty"`
+	ResponseBody          []byte              `json:"response_body,omitempty"`
+	ResponseBodyTruncated bool                `json:"response_body_truncated,omitempty"`
+}
+
+// ConnectionInfo captures an observed TCP connection.
+type ConnectionInfo struct {
+	Source     string  `json:"source"`
+	Target     string  `json:"target"`
+	Ingress    string  `json:"ingress"`
+	BytesIn    int64   `json:"bytes_in"`
+	BytesOut   int64   `json:"bytes_out"`
+	DurationMs float64 `json:"duration_ms"`
+}
+
 // Event is a single entry in the event log.
 type Event struct {
 	Seq         uint64            `json:"seq"`
@@ -92,6 +131,8 @@ type Event struct {
 	Callback    *CallbackRequest  `json:"callback,omitempty"`
 	Result      *CallbackResponse `json:"result,omitempty"`
 	Error       string            `json:"error,omitempty"`
+	Request     *RequestInfo      `json:"request,omitempty"`
+	Connection  *ConnectionInfo   `json:"connection,omitempty"`
 	// Ingresses is populated on environment.up. It maps service name to a
 	// map of ingress name to endpoint, giving clients everything they need
 	// to connect to any service without a follow-up GET request.

--- a/server/orchestrator.go
+++ b/server/orchestrator.go
@@ -122,6 +122,7 @@ func (o *Orchestrator) Orchestrate(env *spec.Environment) (run.Runner, string, e
 				envName:    env.Name,
 				instanceID: instanceID,
 				artifacts:  results,
+				observe:    env.Observe,
 			}
 
 			group[name] = serviceLifecycle(sc, o.Ports)

--- a/server/proxy/event.go
+++ b/server/proxy/event.go
@@ -1,0 +1,39 @@
+package proxy
+
+// Event is the proxy-internal event type emitted by forwarders.
+// The lifecycle layer converts these into server.Event entries.
+type Event struct {
+	Type       string
+	Request    *RequestInfo
+	Connection *ConnectionInfo
+}
+
+// RequestInfo captures an observed HTTP request/response pair.
+type RequestInfo struct {
+	Source       string
+	Target       string
+	Ingress      string
+	Method       string
+	Path         string
+	StatusCode   int
+	LatencyMs    float64
+	RequestSize  int64
+	ResponseSize int64
+
+	RequestHeaders          map[string][]string
+	RequestBody             []byte
+	RequestBodyTruncated    bool
+	ResponseHeaders         map[string][]string
+	ResponseBody            []byte
+	ResponseBodyTruncated   bool
+}
+
+// ConnectionInfo captures an observed TCP connection.
+type ConnectionInfo struct {
+	Source     string
+	Target     string
+	Ingress    string
+	BytesIn    int64
+	BytesOut   int64
+	DurationMs float64
+}

--- a/server/proxy/forwarder.go
+++ b/server/proxy/forwarder.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/matgreaves/rig/spec"
+	"github.com/matgreaves/run"
+)
+
+// Forwarder observes traffic for a single egress edge or external connection.
+// It listens on a single port and forwards to the real service endpoint,
+// emitting events for each request or connection.
+type Forwarder struct {
+	ListenPort int
+	Target     spec.Endpoint // real service endpoint to forward to
+	Source     string        // source service name or "external"
+	TargetSvc  string        // target service name
+	Ingress    string        // target ingress name
+	Protocol   string        // from spec: "http", "tcp", etc.
+	Emit       func(Event)   // publish to event log
+}
+
+// Endpoint returns the proxy endpoint that callers should connect to.
+func (f *Forwarder) Endpoint() spec.Endpoint {
+	return spec.Endpoint{
+		Host:       "127.0.0.1",
+		Port:       f.ListenPort,
+		Protocol:   f.Target.Protocol,
+		Attributes: f.Target.Attributes,
+	}
+}
+
+// Runner returns a run.Runner that listens and forwards traffic.
+// Dispatches to HTTP reverse proxy or TCP relay based on Protocol.
+func (f *Forwarder) Runner() run.Runner {
+	return run.Func(func(ctx context.Context) error {
+		switch f.Protocol {
+		case "http":
+			return f.runHTTP(ctx)
+		default:
+			// TCP relay for tcp, grpc, and anything else.
+			return f.runTCP(ctx)
+		}
+	})
+}
+
+// targetAddr returns host:port of the real service.
+func (f *Forwarder) targetAddr() string {
+	return fmt.Sprintf("%s:%d", f.Target.Host, f.Target.Port)
+}
+
+// listenAddr returns the proxy listen address.
+func (f *Forwarder) listenAddr() string {
+	return fmt.Sprintf("127.0.0.1:%d", f.ListenPort)
+}

--- a/server/proxy/http.go
+++ b/server/proxy/http.go
@@ -1,0 +1,193 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// maxBodyCapture is the maximum number of body bytes captured per request or
+// response for the event log. The full body is always forwarded regardless.
+const maxBodyCapture = 64 * 1024 // 64KB
+
+// runHTTP starts an HTTP reverse proxy that captures request metadata.
+func (f *Forwarder) runHTTP(ctx context.Context) error {
+	target := &url.URL{
+		Scheme: "http",
+		Host:   f.targetAddr(),
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = &observingTransport{
+		inner:   http.DefaultTransport,
+		emit:    f.Emit,
+		source:  f.Source,
+		target:  f.TargetSvc,
+		ingress: f.Ingress,
+	}
+
+	ln, err := net.Listen("tcp", f.listenAddr())
+	if err != nil {
+		return fmt.Errorf("proxy %s→%s: listen: %w", f.Source, f.TargetSvc, err)
+	}
+
+	srv := &http.Server{Handler: proxy}
+
+	go func() {
+		<-ctx.Done()
+		srv.Close()
+	}()
+
+	err = srv.Serve(ln)
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}
+
+// observingTransport wraps an http.RoundTripper to capture headers and bodies.
+type observingTransport struct {
+	inner   http.RoundTripper
+	emit    func(Event)
+	source  string
+	target  string
+	ingress string
+}
+
+func (t *observingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Copy request headers before the transport modifies them.
+	reqHeaders := cloneHeaders(req.Header)
+
+	// Tee request body into a capped buffer as the transport reads it.
+	reqCapture := &cappedBuffer{max: maxBodyCapture}
+	if req.Body != nil {
+		req.Body = readCloser{
+			Reader: io.TeeReader(req.Body, reqCapture),
+			Closer: req.Body,
+		}
+	}
+
+	start := time.Now()
+	resp, err := t.inner.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	latency := time.Since(start)
+
+	respHeaders := cloneHeaders(resp.Header)
+
+	path := req.URL.Path
+	if req.URL.RawQuery != "" {
+		path += "?" + req.URL.RawQuery
+	}
+
+	// Wrap response body to tee into a capped buffer. The event is emitted
+	// when the reverse proxy closes the body after streaming to the client.
+	respCapture := &cappedBuffer{max: maxBodyCapture}
+	resp.Body = &observedBody{
+		reader:  io.TeeReader(resp.Body, respCapture),
+		closer:  resp.Body,
+		capture: respCapture,
+		emit: func() {
+			t.emit(Event{
+				Type: "request.completed",
+				Request: &RequestInfo{
+					Source:                t.source,
+					Target:                t.target,
+					Ingress:               t.ingress,
+					Method:                req.Method,
+					Path:                  path,
+					StatusCode:            resp.StatusCode,
+					LatencyMs:             float64(latency.Microseconds()) / 1000.0,
+					RequestSize:           reqCapture.total,
+					ResponseSize:          respCapture.total,
+					RequestHeaders:        reqHeaders,
+					RequestBody:           reqCapture.bytes(),
+					RequestBodyTruncated:  reqCapture.truncated,
+					ResponseHeaders:       respHeaders,
+					ResponseBody:          respCapture.bytes(),
+					ResponseBodyTruncated: respCapture.truncated,
+				},
+			})
+		},
+	}
+
+	return resp, nil
+}
+
+// cappedBuffer captures up to max bytes written to it, tracking total bytes
+// and whether any data was truncated.
+type cappedBuffer struct {
+	buf       bytes.Buffer
+	max       int
+	truncated bool
+	total     int64
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	b.total += int64(n)
+	if b.truncated {
+		return n, nil
+	}
+	remaining := b.max - b.buf.Len()
+	if n <= remaining {
+		b.buf.Write(p)
+	} else {
+		if remaining > 0 {
+			b.buf.Write(p[:remaining])
+		}
+		b.truncated = true
+	}
+	return n, nil
+}
+
+func (b *cappedBuffer) bytes() []byte {
+	if b.buf.Len() == 0 {
+		return nil
+	}
+	return b.buf.Bytes()
+}
+
+// observedBody wraps a response body, teeing reads into a capture buffer
+// and emitting a traffic event when closed.
+type observedBody struct {
+	reader  io.Reader
+	closer  io.Closer
+	capture *cappedBuffer
+	emit    func()
+	once    sync.Once
+}
+
+func (b *observedBody) Read(p []byte) (int, error) {
+	return b.reader.Read(p)
+}
+
+func (b *observedBody) Close() error {
+	// Drain any unread body so respCapture.total reflects the full size.
+	io.Copy(io.Discard, b.reader)
+	err := b.closer.Close()
+	b.once.Do(b.emit)
+	return err
+}
+
+// readCloser combines a Reader and Closer into an io.ReadCloser.
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// cloneHeaders returns a deep copy of an http.Header.
+func cloneHeaders(h http.Header) map[string][]string {
+	if len(h) == 0 {
+		return nil
+	}
+	return map[string][]string(h.Clone())
+}

--- a/server/proxy/tcp.go
+++ b/server/proxy/tcp.go
@@ -1,0 +1,110 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// runTCP starts a TCP relay that captures connection metadata.
+func (f *Forwarder) runTCP(ctx context.Context) error {
+	ln, err := net.Listen("tcp", f.listenAddr())
+	if err != nil {
+		return fmt.Errorf("proxy %s→%s: listen: %w", f.Source, f.TargetSvc, err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("proxy %s→%s: accept: %w", f.Source, f.TargetSvc, err)
+		}
+		go f.handleTCPConn(ctx, conn)
+	}
+}
+
+func (f *Forwarder) handleTCPConn(ctx context.Context, client net.Conn) {
+	start := time.Now()
+
+	f.Emit(Event{
+		Type: "connection.opened",
+		Connection: &ConnectionInfo{
+			Source:  f.Source,
+			Target:  f.TargetSvc,
+			Ingress: f.Ingress,
+		},
+	})
+
+	target, err := net.DialTimeout("tcp", f.targetAddr(), 5*time.Second)
+	if err != nil {
+		client.Close()
+		f.Emit(Event{
+			Type: "connection.closed",
+			Connection: &ConnectionInfo{
+				Source:     f.Source,
+				Target:     f.TargetSvc,
+				Ingress:    f.Ingress,
+				DurationMs: float64(time.Since(start).Microseconds()) / 1000.0,
+			},
+		})
+		return
+	}
+
+	// Close both when context is cancelled.
+	go func() {
+		<-ctx.Done()
+		client.Close()
+		target.Close()
+	}()
+
+	var bytesIn, bytesOut atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// client → target
+	go func() {
+		defer wg.Done()
+		n, _ := io.Copy(target, client)
+		bytesIn.Store(n)
+		if tc, ok := target.(*net.TCPConn); ok {
+			tc.CloseWrite()
+		}
+	}()
+
+	// target → client
+	go func() {
+		defer wg.Done()
+		n, _ := io.Copy(client, target)
+		bytesOut.Store(n)
+		if tc, ok := client.(*net.TCPConn); ok {
+			tc.CloseWrite()
+		}
+	}()
+
+	wg.Wait()
+	client.Close()
+	target.Close()
+
+	f.Emit(Event{
+		Type: "connection.closed",
+		Connection: &ConnectionInfo{
+			Source:     f.Source,
+			Target:     f.TargetSvc,
+			Ingress:    f.Ingress,
+			BytesIn:    bytesIn.Load(),
+			BytesOut:   bytesOut.Load(),
+			DurationMs: float64(time.Since(start).Microseconds()) / 1000.0,
+		},
+	})
+}

--- a/spec/decode.go
+++ b/spec/decode.go
@@ -13,6 +13,7 @@ func DecodeEnvironment(data []byte) (Environment, error) {
 	var raw struct {
 		Name     string                      `json:"name"`
 		Services map[string]json.RawMessage  `json:"services"`
+		Observe  bool                        `json:"observe"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return Environment{}, err
@@ -26,6 +27,7 @@ func DecodeEnvironment(data []byte) (Environment, error) {
 	env := Environment{
 		Name:     raw.Name,
 		Services: make(map[string]Service, len(raw.Services)),
+		Observe:  raw.Observe,
 	}
 
 	for svcName, svcData := range raw.Services {

--- a/spec/environment.go
+++ b/spec/environment.go
@@ -9,6 +9,11 @@ type Environment struct {
 
 	// Services maps service names to their specs.
 	Services map[string]Service `json:"services"`
+
+	// Observe enables transparent traffic proxying. When true, rig inserts
+	// a proxy on every egress edge and every external connection, capturing
+	// request/connection events in the event log.
+	Observe bool `json:"observe,omitempty"`
 }
 
 // ResolvedEnvironment is the runtime view of an environment after all


### PR DESCRIPTION
## Summary

- **Transparent traffic proxy** (`WithObserve()`): inserts HTTP reverse proxies and TCP relays on every egress edge and external connection, capturing full request/response metadata in the event log — no service code changes needed
- **Health check diagnostics**: `Poll()` now tracks the last check error and includes it in timeout messages (e.g. "readiness check failed after 30s (last error: connection refused)") instead of the opaque "context deadline exceeded"; emits `health.check_failed` events per failed probe
- **Quieter test output**: only `service.failed` and `artifact.failed` go to `t.Log`; all other detail lives in the `.log`/`.jsonl` summary files where it's better organized

## Details

### Traffic proxy

Every proxy is an egress proxy — one per traffic flow, no chaining. The test code gets its own external proxy per ingress (returned by `env.Endpoint()`).

| Protocol | Implementation | Captures |
|----------|---------------|----------|
| HTTP | `httputil.ReverseProxy` with instrumented transport | Method, path, status, latency, headers, bodies (up to 64KB via `io.TeeReader`) |
| TCP | Bidirectional `io.Copy` relay | Connection open/close, bytes in/out, duration |

New event types: `request.completed`, `connection.opened`, `connection.closed`, `proxy.published`, `health.check_failed`

### New files

- `server/proxy/forwarder.go` — Forwarder type, port binding, protocol dispatch
- `server/proxy/event.go` — proxy-internal event types
- `server/proxy/http.go` — HTTP reverse proxy with `cappedBuffer` + `observedBody` for streaming body capture
- `server/proxy/tcp.go` — TCP relay with atomic byte counting

## Test plan

- [x] `TestObserve` — HTTP traffic captured through proxy with full headers/bodies
- [x] `TestObserveTCP` — TCP connection events with byte counts
- [x] `TestPoll_Timeout` — timeout error includes last check error
- [x] `TestPoll_OnFailureCallback` — callback fires on each failed probe
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)