### PR TITLE
Filter service.log from SSE, include log tail in failure events

### DIFF
--- a/server/orchestrator.go
+++ b/server/orchestrator.go
@@ -195,11 +195,15 @@ func (o *Orchestrator) Orchestrate(env *spec.Environment) (run.Runner, string, e
 		}
 		if err := servicePhase.Run(ctx); err != nil {
 			if ctx.Err() == nil {
+				errMsg := err.Error()
+				if tail := o.Log.ServiceLogTail(failedService, 10); tail != "" {
+					errMsg += "\n" + tail
+				}
 				o.Log.Publish(Event{
 					Type:        EventEnvironmentFailing,
 					Environment: env.Name,
 					Service:     failedService,
-					Error:       err.Error(),
+					Error:       errMsg,
 				})
 			}
 			return err


### PR DESCRIPTION
## Summary

- **SSE stream now excludes `service.log` events** — prevents high-volume service output from filling the 256-event subscriber buffer and silently dropping lifecycle events (e.g. `callback.request`, which would cause a deadlock)
- **`environment.failing` event now includes the last 10 log lines** from the failed service in its error field, preserving failure diagnostics without requiring the client to buffer logs
- **Client SDK cleanup** — removed log tail buffering, `wireLogEntry` type, and log-inlining logic that depended on receiving log events over SSE

Logs are still captured server-side in the event log and available via `GET /log` and the timeline files on `DELETE`.

## Test plan

- [x] All existing tests pass (no test relied on service.log over SSE)
- [x] Verify failure diagnostics still show log context in error output
- [x] Verify `GET /log` still returns full event history including service.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)