### PR TITLE
Fix duplicated error info in environment.failing output

### DIFF
--- a/client/stream.go
+++ b/client/stream.go
@@ -51,7 +51,7 @@ func (s *streamState) recordEvent(ev wireEvent) {
 	}
 
 	line := fmt.Sprintf("  %5.2fs  %-22s %s", elapsed, ev.Type, label)
-	if ev.Error != "" {
+	if ev.Error != "" && ev.Type != "environment.failing" {
 		line += "    " + ev.Error
 	}
 	if ev.Type == "environment.failing" {

--- a/server/orchestrator.go
+++ b/server/orchestrator.go
@@ -195,15 +195,11 @@ func (o *Orchestrator) Orchestrate(env *spec.Environment) (run.Runner, string, e
 		}
 		if err := servicePhase.Run(ctx); err != nil {
 			if ctx.Err() == nil {
-				errMsg := err.Error()
-				if tail := o.Log.ServiceLogTail(failedService, 10); tail != "" {
-					errMsg += "\n" + tail
-				}
 				o.Log.Publish(Event{
 					Type:        EventEnvironmentFailing,
 					Environment: env.Name,
 					Service:     failedService,
-					Error:       errMsg,
+					Error:       err.Error(),
 				})
 			}
 			return err


### PR DESCRIPTION
## Summary
- Stop embedding the service log tail in `environment.failing`'s Error field — it was duplicating crash details already shown under `service.failed`
- Skip appending the error to the `environment.failing` timeline entry on the client side, since it's already in the failures header

## Test plan
- [x] `TestUp/ServiceCrash` passes
- [x] `TestServer/ServiceCrashEvents` passes
- [x] `TestServer/MultiServiceCrashCleanup` passes
- [x] `.log` timeline formatting verified — log tail appears once under `service.failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)