### PR TITLE
Add exec hooks for container and postgres services

### DIFF
--- a/client/container.go
+++ b/client/container.go
@@ -90,6 +90,15 @@ func (d *ContainerDef) EgressAs(name, service string, ingress ...string) *Contai
 	return d
 }
 
+// Exec registers an exec init hook that runs a command inside the container
+// after it becomes healthy. The command is executed server-side via docker exec.
+//
+//	rig.Container("redis:7").Port(6379).Exec("redis-cli", "SET", "key", "value")
+func (d *ContainerDef) Exec(cmd ...string) *ContainerDef {
+	d.hooks.init = append(d.hooks.init, execHook{command: cmd})
+	return d
+}
+
 // InitHook registers a client-side init hook function.
 func (d *ContainerDef) InitHook(fn func(ctx context.Context, w Wiring) error) *ContainerDef {
 	d.hooks.init = append(d.hooks.init, hookFunc(fn))

--- a/client/convert.go
+++ b/client/convert.go
@@ -273,6 +273,12 @@ func hookToSpec(h hook, handlers map[string]hookFunc) (*spec.HookSpec, error) {
 			Type:   "sql",
 			Config: cfg,
 		}, nil
+	case execHook:
+		cfg, _ := json.Marshal(map[string]any{"command": hk.command})
+		return &spec.HookSpec{
+			Type:   "exec",
+			Config: cfg,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported hook type: %T", h)
 	}

--- a/client/postgres.go
+++ b/client/postgres.go
@@ -56,6 +56,15 @@ func (d *PostgresDef) InitSQL(statements ...string) *PostgresDef {
 	return d
 }
 
+// Exec registers an exec init hook that runs a command inside the container
+// after it becomes healthy. The command is executed server-side via docker exec.
+//
+//	rig.Postgres().Exec("psql", "-U", "postgres", "-c", "CREATE EXTENSION pg_trgm")
+func (d *PostgresDef) Exec(cmd ...string) *PostgresDef {
+	d.hooks.init = append(d.hooks.init, execHook{command: cmd})
+	return d
+}
+
 // InitHook registers a client-side init hook function.
 func (d *PostgresDef) InitHook(fn func(ctx context.Context, w Wiring) error) *PostgresDef {
 	d.hooks.init = append(d.hooks.init, hookFunc(fn))

--- a/client/rig.go
+++ b/client/rig.go
@@ -99,6 +99,12 @@ type sqlHook struct {
 
 func (sqlHook) rigHook() {}
 
+type execHook struct {
+	command []string
+}
+
+func (execHook) rigHook() {}
+
 // startFunc is a function that runs as a service in the test process.
 type startFunc func(ctx context.Context) error
 


### PR DESCRIPTION
## Summary

- Adds `.Exec()` builder method to `ContainerDef` and `PostgresDef`, enabling server-side `docker exec` commands as init hooks
- Extracts shared `ExecInContainer` helper, replacing the duplicated `execPsql` in postgres.go
- `Container.Init` polls for the container to be running before executing, fixing a race where no-ingress services fire init hooks before `Container.Runner` has created the Docker container

## Test plan

- [x] `ContainerExecHook` — exec hook on container with ingress (happy path)
- [x] `ContainerExecHookFailure` — exec hook with bad command propagates error
- [x] `ContainerExecHookNoIngress` — exec hook on no-ingress container (the race that this fixes)
- [x] Existing `Postgres`, `PostgresInitSQL`, `PostgresInitSQL_BadSQL` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)