### PR TITLE
Rewrite address-derived attributes in observe proxy

### DIFF
--- a/internal/server/proxy/forwarder.go
+++ b/internal/server/proxy/forwarder.go
@@ -22,12 +22,15 @@ type Forwarder struct {
 }
 
 // Endpoint returns the proxy endpoint that callers should connect to.
+// Address-derived attributes declared in Target.AddressAttrs are rewritten
+// to reflect the proxy's listen address.
 func (f *Forwarder) Endpoint() spec.Endpoint {
 	return spec.Endpoint{
-		Host:       "127.0.0.1",
-		Port:       f.ListenPort,
-		Protocol:   f.Target.Protocol,
-		Attributes: f.Target.Attributes,
+		Host:         "127.0.0.1",
+		Port:         f.ListenPort,
+		Protocol:     f.Target.Protocol,
+		Attributes:   spec.RewriteAddressAttrs(f.Target, "127.0.0.1", f.ListenPort),
+		AddressAttrs: f.Target.AddressAttrs,
 	}
 }
 

--- a/internal/server/proxy/forwarder_test.go
+++ b/internal/server/proxy/forwarder_test.go
@@ -1,0 +1,123 @@
+package proxy_test
+
+import (
+	"testing"
+
+	"github.com/matgreaves/rig/internal/server/proxy"
+	"github.com/matgreaves/rig/internal/spec"
+)
+
+func TestForwarderEndpoint_RewritesAddressAttrs(t *testing.T) {
+	f := &proxy.Forwarder{
+		ListenPort: 9999,
+		Target: spec.Endpoint{
+			Host:     "10.0.0.5",
+			Port:     5432,
+			Protocol: spec.TCP,
+			Attributes: map[string]any{
+				"PGHOST":     "10.0.0.5",
+				"PGPORT":     "5432",
+				"PGDATABASE": "mydb",
+			},
+			AddressAttrs: map[string]spec.AddrAttr{
+				"PGHOST": spec.AttrHost,
+				"PGPORT": spec.AttrPort,
+			},
+		},
+	}
+
+	ep := f.Endpoint()
+
+	if ep.Host != "127.0.0.1" {
+		t.Errorf("Host = %q, want 127.0.0.1", ep.Host)
+	}
+	if ep.Port != 9999 {
+		t.Errorf("Port = %d, want 9999", ep.Port)
+	}
+	if ep.Protocol != spec.TCP {
+		t.Errorf("Protocol = %q, want tcp", ep.Protocol)
+	}
+
+	// Address-derived attrs should reflect the proxy address.
+	if got := ep.Attributes["PGHOST"]; got != "127.0.0.1" {
+		t.Errorf("PGHOST = %v, want 127.0.0.1", got)
+	}
+	if got := ep.Attributes["PGPORT"]; got != "9999" {
+		t.Errorf("PGPORT = %v, want 9999", got)
+	}
+
+	// Non-address attrs should be preserved.
+	if got := ep.Attributes["PGDATABASE"]; got != "mydb" {
+		t.Errorf("PGDATABASE = %v, want mydb", got)
+	}
+
+	// AddressAttrs should be preserved for downstream rewriters.
+	if ep.AddressAttrs["PGHOST"] != spec.AttrHost {
+		t.Errorf("AddressAttrs[PGHOST] = %v, want %v", ep.AddressAttrs["PGHOST"], spec.AttrHost)
+	}
+}
+
+func TestForwarderEndpoint_HostPort(t *testing.T) {
+	f := &proxy.Forwarder{
+		ListenPort: 7233,
+		Target: spec.Endpoint{
+			Host:     "10.0.0.5",
+			Port:     7233,
+			Protocol: spec.GRPC,
+			Attributes: map[string]any{
+				"TEMPORAL_ADDRESS":   "10.0.0.5:7233",
+				"TEMPORAL_NAMESPACE": "default",
+			},
+			AddressAttrs: map[string]spec.AddrAttr{
+				"TEMPORAL_ADDRESS": spec.AttrHostPort,
+			},
+		},
+	}
+
+	ep := f.Endpoint()
+
+	if got := ep.Attributes["TEMPORAL_ADDRESS"]; got != "127.0.0.1:7233" {
+		t.Errorf("TEMPORAL_ADDRESS = %v, want 127.0.0.1:7233", got)
+	}
+	if got := ep.Attributes["TEMPORAL_NAMESPACE"]; got != "default" {
+		t.Errorf("TEMPORAL_NAMESPACE = %v, want default", got)
+	}
+}
+
+func TestForwarderEndpoint_NoAddressAttrs(t *testing.T) {
+	f := &proxy.Forwarder{
+		ListenPort: 8080,
+		Target: spec.Endpoint{
+			Host:     "10.0.0.5",
+			Port:     8080,
+			Protocol: spec.HTTP,
+			Attributes: map[string]any{
+				"FOO": "bar",
+			},
+		},
+	}
+
+	ep := f.Endpoint()
+
+	// Without AddressAttrs, attributes are copied unchanged.
+	if got := ep.Attributes["FOO"]; got != "bar" {
+		t.Errorf("FOO = %v, want bar", got)
+	}
+}
+
+func TestForwarderEndpoint_NilAttributes(t *testing.T) {
+	f := &proxy.Forwarder{
+		ListenPort: 8080,
+		Target: spec.Endpoint{
+			Host:     "10.0.0.5",
+			Port:     8080,
+			Protocol: spec.HTTP,
+		},
+	}
+
+	ep := f.Endpoint()
+
+	if ep.Attributes != nil {
+		t.Errorf("Attributes = %v, want nil", ep.Attributes)
+	}
+}

--- a/internal/server/service/container.go
+++ b/internal/server/service/container.go
@@ -325,6 +325,9 @@ func adjustIngressEndpoints(ingresses map[string]spec.Endpoint, specs map[string
 			ep.Port = is.ContainerPort
 		}
 
+		// Rewrite declared address-derived attrs first, then fall back
+		// to convention-based adjustAttrs for user-specified attributes.
+		ep.Attributes = spec.RewriteAddressAttrs(ep, ep.Host, ep.Port)
 		ep.Attributes = adjustAttrs(ep.Attributes, origHost, ep.Host, origPort, strconv.Itoa(ep.Port))
 		adjusted[name] = ep
 	}
@@ -339,6 +342,9 @@ func adjustEgressEndpoints(egresses map[string]spec.Endpoint, hostIP string) map
 	for name, ep := range egresses {
 		origHost := ep.Host
 		ep.Host = strings.ReplaceAll(ep.Host, "127.0.0.1", hostIP)
+		// Rewrite declared address-derived attrs first, then fall back
+		// to convention-based adjustAttrs for user-specified attributes.
+		ep.Attributes = spec.RewriteAddressAttrs(ep, ep.Host, ep.Port)
 		ep.Attributes = adjustAttrs(ep.Attributes, origHost, ep.Host, "", "")
 		adjusted[name] = ep
 	}

--- a/internal/server/service/postgres.go
+++ b/internal/server/service/postgres.go
@@ -57,6 +57,10 @@ func (Postgres) Publish(_ context.Context, params PublishParams) (map[string]spe
 		ep.Attributes["PGDATABASE"] = params.ServiceName
 		ep.Attributes["PGUSER"] = postgresDefaultUser
 		ep.Attributes["PGPASSWORD"] = postgresDefaultPassword
+		ep.AddressAttrs = map[string]spec.AddrAttr{
+			"PGHOST": spec.AttrHost,
+			"PGPORT": spec.AttrPort,
+		}
 		endpoints[name] = ep
 	}
 	return endpoints, nil

--- a/internal/server/service/temporal.go
+++ b/internal/server/service/temporal.go
@@ -53,6 +53,9 @@ func (Temporal) Publish(_ context.Context, params PublishParams) (map[string]spe
 		}
 		ep.Attributes["TEMPORAL_ADDRESS"] = fmt.Sprintf("%s:%d", ep.Host, ep.Port)
 		ep.Attributes["TEMPORAL_NAMESPACE"] = cfg.Namespace
+		ep.AddressAttrs = map[string]spec.AddrAttr{
+			"TEMPORAL_ADDRESS": spec.AttrHostPort,
+		}
 		endpoints["default"] = ep
 	}
 	return endpoints, nil

--- a/internal/spec/endpoint.go
+++ b/internal/spec/endpoint.go
@@ -1,5 +1,7 @@
 package spec
 
+import "strconv"
+
 // Protocol identifies the application-layer protocol an ingress speaks.
 type Protocol string
 
@@ -23,12 +25,46 @@ func (p Protocol) Valid() bool {
 	return false
 }
 
+// AddrAttr declares how an endpoint attribute derives from the address.
+type AddrAttr string
+
+const (
+	AttrHost     AddrAttr = "host"     // value = ep.Host
+	AttrPort     AddrAttr = "port"     // value = strconv.Itoa(ep.Port)
+	AttrHostPort AddrAttr = "hostport" // value = ep.Host + ":" + strconv.Itoa(ep.Port)
+)
+
 // Endpoint is a fully resolved, concrete address produced at runtime.
 // The spec never contains endpoints — they are created by the server
 // during the publish phase when ports are allocated.
 type Endpoint struct {
-	Host       string         `json:"host"`
-	Port       int            `json:"port"`
-	Protocol   Protocol       `json:"protocol"`
-	Attributes map[string]any `json:"attributes,omitempty"`
+	Host         string              `json:"host"`
+	Port         int                 `json:"port"`
+	Protocol     Protocol            `json:"protocol"`
+	Attributes   map[string]any      `json:"attributes,omitempty"`
+	AddressAttrs map[string]AddrAttr `json:"address_attrs,omitempty"`
+}
+
+// RewriteAddressAttrs returns a copy of source.Attributes with entries
+// declared in source.AddressAttrs rewritten to reflect newHost and newPort.
+// Non-declared attributes are copied unchanged.
+func RewriteAddressAttrs(source Endpoint, newHost string, newPort int) map[string]any {
+	if len(source.Attributes) == 0 {
+		return source.Attributes
+	}
+	attrs := make(map[string]any, len(source.Attributes))
+	for k, v := range source.Attributes {
+		attrs[k] = v
+	}
+	for key, kind := range source.AddressAttrs {
+		switch kind {
+		case AttrHost:
+			attrs[key] = newHost
+		case AttrPort:
+			attrs[key] = strconv.Itoa(newPort)
+		case AttrHostPort:
+			attrs[key] = newHost + ":" + strconv.Itoa(newPort)
+		}
+	}
+	return attrs
 }


### PR DESCRIPTION
## Summary

- Service types like Postgres and Temporal publish connection attributes (`PGHOST`, `PGPORT`, `TEMPORAL_ADDRESS`) derived from the endpoint address. In observe mode the proxy rewrote `Host`/`Port` but left these attributes pointing at the original service, so tools reading env vars (`psql`, `tctl`, `temporalx.Dial`) bypassed the proxy entirely.
- Add an `AddressAttrs` declaration on `spec.Endpoint` — service types declare which attributes are address-derived and how (`host`, `port`, or `hostport`). The proxy's `Forwarder.Endpoint()` and the container's `adjustIngressEndpoints`/`adjustEgressEndpoints` now use `RewriteAddressAttrs` to produce correct values.
- Postgres declares `PGHOST` (host) and `PGPORT` (port); Temporal declares `TEMPORAL_ADDRESS` (hostport).

## Test plan

- [x] `TestRewriteAddressAttrs` — unit tests for all three kinds, nil/empty, no declarations, mutation safety
- [x] `TestEndpointAddressAttrsRoundTrip` / `TestEndpointOmitsEmptyAddressAttrs` — JSON serialization
- [x] `TestForwarderEndpoint_*` — proxy endpoint rewriting for postgres-style, temporal-style, no attrs, nil attrs
- [x] `TestObserveAttributes` — integration test: Temporal with observe mode, verifies `TEMPORAL_ADDRESS` matches proxy address
- [x] `make test` — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes: https://github.com/matgreaves/rig/issues/17