### PR TITLE
Capture gRPC bodies and decode via reflection

### DIFF
--- a/internal/go.mod
+++ b/internal/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/docker/go-connections v0.6.0
 	github.com/matgreaves/rig v0.0.0
 	github.com/matgreaves/run v0.0.0-20260218110328-eb38e0ac8e05
+	golang.org/x/net v0.49.0
 	google.golang.org/grpc v1.79.1
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -33,12 +35,10 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
-	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 )
 

--- a/internal/server/eventlog.go
+++ b/internal/server/eventlog.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"sort"
 	"strings"
 	"sync"
@@ -136,6 +137,13 @@ type GRPCCallInfo struct {
 	ResponseSize     int64               `json:"response_size"`
 	RequestMetadata  map[string][]string `json:"request_metadata,omitempty"`
 	ResponseMetadata map[string][]string `json:"response_metadata,omitempty"`
+
+	RequestBody           []byte          `json:"request_body,omitempty"`
+	RequestBodyTruncated  bool            `json:"request_body_truncated,omitempty"`
+	ResponseBody          []byte          `json:"response_body,omitempty"`
+	ResponseBodyTruncated bool            `json:"response_body_truncated,omitempty"`
+	RequestBodyDecoded    json.RawMessage `json:"request_body_decoded,omitempty"`
+	ResponseBodyDecoded   json.RawMessage `json:"response_body_decoded,omitempty"`
 }
 
 // Event is a single entry in the event log.

--- a/internal/server/proxy/event.go
+++ b/internal/server/proxy/event.go
@@ -53,4 +53,11 @@ type GRPCCallInfo struct {
 	ResponseSize     int64
 	RequestMetadata  map[string][]string
 	ResponseMetadata map[string][]string
+
+	RequestBody           []byte
+	RequestBodyTruncated  bool
+	ResponseBody          []byte
+	ResponseBodyTruncated bool
+	RequestBodyDecoded    string // JSON from reflection, empty if unavailable
+	ResponseBodyDecoded   string
 }

--- a/internal/server/proxy/forwarder.go
+++ b/internal/server/proxy/forwarder.go
@@ -19,6 +19,7 @@ type Forwarder struct {
 	Ingress    string        // target ingress name
 	Protocol   string        // from spec: "http", "tcp", etc.
 	Emit       func(Event)   // publish to event log
+	Decoder    *grpcDecoder  // set once before traffic flows; nil if reflection unavailable
 }
 
 // Endpoint returns the proxy endpoint that callers should connect to.

--- a/internal/server/proxy/grpc.go
+++ b/internal/server/proxy/grpc.go
@@ -30,10 +30,11 @@ func (f *Forwarder) runGRPC(ctx context.Context) error {
 				return (&net.Dialer{}).DialContext(ctx, network, addr)
 			},
 		},
-		emit:    f.Emit,
-		source:  f.Source,
-		target:  f.TargetSvc,
-		ingress: f.Ingress,
+		emit:       f.Emit,
+		source:     f.Source,
+		target:     f.TargetSvc,
+		ingress:    f.Ingress,
+		getDecoder: func() *grpcDecoder { return f.Decoder },
 	}
 
 	ln, err := net.Listen("tcp", f.listenAddr())

--- a/internal/server/proxy/reflect.go
+++ b/internal/server/proxy/reflect.go
@@ -1,0 +1,229 @@
+package proxy
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// grpcDecoder decodes gRPC request/response bodies into JSON using
+// descriptors obtained via server reflection.
+type grpcDecoder struct {
+	methods map[string]methodDesc // key: "pkg.Service/Method"
+}
+
+type methodDesc struct {
+	input  protoreflect.MessageDescriptor
+	output protoreflect.MessageDescriptor
+}
+
+// ProbeReflection dials the target gRPC server and attempts to fetch service
+// descriptors via the v1 reflection API. Returns nil if reflection is not
+// available or any error occurs. The caller should treat nil as "no decoder".
+func ProbeReflection(ctx context.Context, addr string) *grpcDecoder {
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil
+	}
+	defer conn.Close()
+
+	client := rpb.NewServerReflectionClient(conn)
+	stream, err := client.ServerReflectionInfo(ctx)
+	if err != nil {
+		return nil
+	}
+
+	// List all services.
+	if err := stream.Send(&rpb.ServerReflectionRequest{
+		MessageRequest: &rpb.ServerReflectionRequest_ListServices{ListServices: ""},
+	}); err != nil {
+		return nil
+	}
+	listResp, err := stream.Recv()
+	if err != nil {
+		return nil
+	}
+	listSvcs := listResp.GetListServicesResponse()
+	if listSvcs == nil {
+		return nil
+	}
+
+	// Fetch file descriptors for each service.
+	seen := make(map[string]bool)
+	var allFiles []*descriptorpb.FileDescriptorProto
+	for _, svc := range listSvcs.Service {
+		files, err := fetchFileDescriptors(stream, svc.Name, seen)
+		if err != nil {
+			return nil
+		}
+		allFiles = append(allFiles, files...)
+	}
+
+	if len(allFiles) == 0 {
+		return nil
+	}
+
+	// Build a FileDescriptorSet and resolve into a registry.
+	fds := &descriptorpb.FileDescriptorSet{File: allFiles}
+	resolved, err := protodesc.NewFiles(fds)
+	if err != nil {
+		return nil
+	}
+
+	// Build method map.
+	methods := make(map[string]methodDesc)
+	resolved.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		for i := 0; i < fd.Services().Len(); i++ {
+			sd := fd.Services().Get(i)
+			for j := 0; j < sd.Methods().Len(); j++ {
+				md := sd.Methods().Get(j)
+				key := fmt.Sprintf("%s/%s", sd.FullName(), md.Name())
+				methods[key] = methodDesc{
+					input:  md.Input(),
+					output: md.Output(),
+				}
+			}
+		}
+		return true
+	})
+
+	if len(methods) == 0 {
+		return nil
+	}
+
+	return &grpcDecoder{methods: methods}
+}
+
+// fetchFileDescriptors fetches the file descriptor for a service (by symbol)
+// and all its transitive dependencies.
+func fetchFileDescriptors(
+	stream rpb.ServerReflection_ServerReflectionInfoClient,
+	serviceName string,
+	seen map[string]bool,
+) ([]*descriptorpb.FileDescriptorProto, error) {
+	return fetchDescriptors(stream, &rpb.ServerReflectionRequest{
+		MessageRequest: &rpb.ServerReflectionRequest_FileContainingSymbol{
+			FileContainingSymbol: serviceName,
+		},
+	}, seen)
+}
+
+// fetchDescriptors sends a reflection request, collects the returned file
+// descriptors, and recursively fetches any unseen transitive dependencies.
+func fetchDescriptors(
+	stream rpb.ServerReflection_ServerReflectionInfoClient,
+	req *rpb.ServerReflectionRequest,
+	seen map[string]bool,
+) ([]*descriptorpb.FileDescriptorProto, error) {
+	if err := stream.Send(req); err != nil {
+		return nil, err
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+	fdResp := resp.GetFileDescriptorResponse()
+	if fdResp == nil {
+		return nil, fmt.Errorf("no file descriptor response")
+	}
+
+	var result []*descriptorpb.FileDescriptorProto
+	for _, raw := range fdResp.FileDescriptorProto {
+		fdp := &descriptorpb.FileDescriptorProto{}
+		if err := proto.Unmarshal(raw, fdp); err != nil {
+			return nil, err
+		}
+		name := fdp.GetName()
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		result = append(result, fdp)
+
+		for _, dep := range fdp.Dependency {
+			if seen[dep] {
+				continue
+			}
+			depFiles, err := fetchDescriptors(stream, &rpb.ServerReflectionRequest{
+				MessageRequest: &rpb.ServerReflectionRequest_FileByFilename{
+					FileByFilename: dep,
+				},
+			}, seen)
+			if err != nil {
+				// Non-fatal: some well-known deps may not be served.
+				continue
+			}
+			result = append(result, depFiles...)
+		}
+	}
+	return result, nil
+}
+
+// Decode decodes a gRPC framed body (length-prefixed protobuf) into JSON.
+// svc is "pkg.Service", method is "Method". isRequest selects which descriptor
+// (input or output) to use. Returns "" on any failure.
+func (d *grpcDecoder) Decode(svc, method string, framedData []byte, isRequest bool) string {
+	key := svc + "/" + method
+	md, ok := d.methods[key]
+	if !ok {
+		return ""
+	}
+
+	raw := unpackFrame(framedData)
+	if raw == nil {
+		return ""
+	}
+
+	var desc protoreflect.MessageDescriptor
+	if isRequest {
+		desc = md.input
+	} else {
+		desc = md.output
+	}
+
+	msg := dynamicpb.NewMessage(desc)
+	if err := proto.Unmarshal(raw, msg); err != nil {
+		return ""
+	}
+
+	out, err := protojson.Marshal(msg)
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// unpackFrame strips the first gRPC length-prefixed frame header (5 bytes:
+// 1 byte compressed flag + 4 bytes big-endian length). Returns nil for
+// compressed, incomplete, or empty frames.
+func unpackFrame(data []byte) []byte {
+	if len(data) < 5 {
+		return nil
+	}
+	compressed := data[0]
+	if compressed != 0 {
+		return nil // compressed frame, can't decode
+	}
+	msgLen := binary.BigEndian.Uint32(data[1:5])
+	if msgLen == 0 {
+		return nil // empty frame
+	}
+	payload := data[5:]
+	if uint32(len(payload)) < msgLen {
+		return nil // incomplete frame
+	}
+	return payload[:msgLen]
+}

--- a/internal/server/proxy/reflect_test.go
+++ b/internal/server/proxy/reflect_test.go
@@ -1,0 +1,211 @@
+package proxy
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+func TestUnpackFrame(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want []byte
+	}{
+		{
+			name: "nil input",
+			data: nil,
+			want: nil,
+		},
+		{
+			name: "too short",
+			data: []byte{0, 0, 0, 0},
+			want: nil,
+		},
+		{
+			name: "compressed flag set",
+			data: []byte{1, 0, 0, 0, 3, 'a', 'b', 'c'},
+			want: nil,
+		},
+		{
+			name: "incomplete payload",
+			data: []byte{0, 0, 0, 0, 5, 'a', 'b'},
+			want: nil,
+		},
+		{
+			name: "empty payload",
+			data: []byte{0, 0, 0, 0, 0},
+			want: nil,
+		},
+		{
+			name: "valid frame",
+			data: makeFrame([]byte("hello")),
+			want: []byte("hello"),
+		},
+		{
+			name: "extra trailing data ignored",
+			data: append(makeFrame([]byte("hi")), 'x', 'y', 'z'),
+			want: []byte("hi"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unpackFrame(tt.data)
+			if tt.want == nil && got != nil {
+				t.Errorf("got %v, want nil", got)
+			} else if tt.want != nil && got == nil {
+				t.Errorf("got nil, want %v", tt.want)
+			} else if string(got) != string(tt.want) {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGRPCDecoderDecode(t *testing.T) {
+	// Build a minimal file descriptor with a service and method.
+	fdp := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("test.proto"),
+		Syntax:  proto.String("proto3"),
+		Package: proto.String("test"),
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("Req"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{
+						Name:   proto.String("name"),
+						Number: proto.Int32(1),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+						Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+					},
+				},
+			},
+			{
+				Name: proto.String("Resp"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{
+						Name:   proto.String("value"),
+						Number: proto.Int32(1),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
+						Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+					},
+				},
+			},
+		},
+		Service: []*descriptorpb.ServiceDescriptorProto{
+			{
+				Name: proto.String("Greeter"),
+				Method: []*descriptorpb.MethodDescriptorProto{
+					{
+						Name:       proto.String("Hello"),
+						InputType:  proto.String(".test.Req"),
+						OutputType: proto.String(".test.Resp"),
+					},
+				},
+			},
+		},
+	}
+
+	fds := &descriptorpb.FileDescriptorSet{File: []*descriptorpb.FileDescriptorProto{fdp}}
+	resolved, err := protodesc.NewFiles(fds)
+	if err != nil {
+		t.Fatalf("protodesc.NewFiles: %v", err)
+	}
+
+	methods := make(map[string]methodDesc)
+	resolved.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		for i := 0; i < fd.Services().Len(); i++ {
+			sd := fd.Services().Get(i)
+			for j := 0; j < sd.Methods().Len(); j++ {
+				md := sd.Methods().Get(j)
+				key := string(sd.FullName()) + "/" + string(md.Name())
+				methods[key] = methodDesc{
+					input:  md.Input(),
+					output: md.Output(),
+				}
+			}
+		}
+		return true
+	})
+
+	decoder := &grpcDecoder{methods: methods}
+
+	// Build a framed request: Req{name: "world"}
+	reqMsg := dynamicpb.NewMessage(methods["test.Greeter/Hello"].input)
+	reqMsg.Set(reqMsg.Descriptor().Fields().ByName("name"), protoreflect.ValueOfString("world"))
+	reqBytes, err := proto.Marshal(reqMsg)
+	if err != nil {
+		t.Fatalf("marshal req: %v", err)
+	}
+	reqFrame := makeFrame(reqBytes)
+
+	// Build a framed response: Resp{value: 42}
+	respMsg := dynamicpb.NewMessage(methods["test.Greeter/Hello"].output)
+	respMsg.Set(respMsg.Descriptor().Fields().ByName("value"), protoreflect.ValueOfInt32(42))
+	respBytes, err := proto.Marshal(respMsg)
+	if err != nil {
+		t.Fatalf("marshal resp: %v", err)
+	}
+	respFrame := makeFrame(respBytes)
+
+	t.Run("decode request", func(t *testing.T) {
+		got := decoder.Decode("test.Greeter", "Hello", reqFrame, true)
+		if got == "" {
+			t.Fatal("Decode returned empty string")
+		}
+		// Should contain "world"
+		if !strings.Contains(got, "world") {
+			t.Errorf("decoded JSON %q does not contain 'world'", got)
+		}
+	})
+
+	t.Run("decode response", func(t *testing.T) {
+		got := decoder.Decode("test.Greeter", "Hello", respFrame, false)
+		if got == "" {
+			t.Fatal("Decode returned empty string")
+		}
+		// Should contain 42
+		if !strings.Contains(got, "42") {
+			t.Errorf("decoded JSON %q does not contain '42'", got)
+		}
+	})
+
+	t.Run("unknown method", func(t *testing.T) {
+		got := decoder.Decode("test.Greeter", "Unknown", reqFrame, true)
+		if got != "" {
+			t.Errorf("expected empty string for unknown method, got %q", got)
+		}
+	})
+
+	t.Run("nil frame", func(t *testing.T) {
+		got := decoder.Decode("test.Greeter", "Hello", nil, true)
+		if got != "" {
+			t.Errorf("expected empty string for nil frame, got %q", got)
+		}
+	})
+
+	t.Run("compressed frame", func(t *testing.T) {
+		compressed := append([]byte{1}, reqFrame[1:]...)
+		got := decoder.Decode("test.Greeter", "Hello", compressed, true)
+		if got != "" {
+			t.Errorf("expected empty string for compressed frame, got %q", got)
+		}
+	})
+}
+
+// makeFrame wraps raw protobuf bytes in a gRPC length-prefixed frame.
+func makeFrame(payload []byte) []byte {
+	frame := make([]byte, 5+len(payload))
+	frame[0] = 0 // not compressed
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(payload)))
+	copy(frame[5:], payload)
+	return frame
+}
+


### PR DESCRIPTION
## Summary

- Always capture raw gRPC request/response bodies (length-prefixed protobuf frames) in `grpc.call.completed` events, matching HTTP body capture
- When the target server supports gRPC reflection (v1), decode bodies into human-readable JSON alongside the raw bytes
- Reflection probe runs deterministically after `service.healthy`, before `init` — no retries, no races

## Design

**Layer 1 — Raw capture (always):** The `cappedBuffer` tee already captures gRPC body bytes but only used them for size counting. Now published as `request_body`/`response_body` in `GRPCCallInfo`.

**Layer 2 — Reflection decode (opportunistic):** `ProbeReflection` dials the target, lists services via v1 reflection, fetches file descriptors with transitive deps, and builds a method→descriptor map. `Decode` unpacks the gRPC frame header, unmarshals via `dynamicpb`, and returns JSON. Returns `""` on any failure — fail-open by design.

**Lazy closure for decoder:** Forwarders start before the reflection probe runs (they're in the same `run.Group`). The `observingTransport` reads the decoder via `func() *grpcDecoder` closure rather than a direct pointer, so it sees the decoder once it's set.

## Test plan

- [x] `TestUnpackFrame` — edge cases: nil, short, compressed, incomplete, empty, valid, trailing data
- [x] `TestGRPCDecoderDecode` — synthetic descriptor, request/response decode, unknown method, nil/compressed frames
- [x] `TestObserveGRPC` — raw bodies always present, decoded response JSON present (Temporal dev server supports reflection)
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)