### PR TITLE
Add connect.LogWriter for Func service log capture

### DIFF
--- a/client/logwriter.go
+++ b/client/logwriter.go
@@ -1,0 +1,123 @@
+package rig
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+)
+
+// rigLogWriter is an io.Writer that ships log lines to rigd as service.log
+// events. Partial writes are buffered until a newline is seen. Complete lines
+// are sent to a background goroutine via a channel so that Write never blocks
+// on HTTP I/O.
+//
+// Safe for concurrent use.
+type rigLogWriter struct {
+	serverURL string
+	envID     string
+	service   string
+
+	mu   sync.Mutex
+	buf  bytes.Buffer
+	ch   chan string
+	done chan struct{}
+}
+
+func newLogWriter(serverURL, envID, service string) *rigLogWriter {
+	w := &rigLogWriter{
+		serverURL: serverURL,
+		envID:     envID,
+		service:   service,
+		ch:        make(chan string, 256),
+		done:      make(chan struct{}),
+	}
+	go w.drain()
+	return w
+}
+
+// drain batches queued log lines and posts them to rigd. Each iteration
+// takes one line from the channel, then drains any additional lines that
+// are ready, and sends them as a single newline-joined event. This
+// naturally batches bursts while keeping latency low during quiet periods.
+func (w *rigLogWriter) drain() {
+	defer close(w.done)
+	for first := range w.ch {
+		var batch []string
+		batch = append(batch, first)
+
+		// Drain any additional lines that are already queued.
+	gather:
+		for {
+			select {
+			case line, ok := <-w.ch:
+				if !ok {
+					break gather
+				}
+				batch = append(batch, line)
+			default:
+				break gather
+			}
+		}
+
+		postClientEvent(w.serverURL, w.envID, struct {
+			Type    string `json:"type"`
+			Service string `json:"service"`
+			Stream  string `json:"stream"`
+			LogData string `json:"log_data"`
+		}{
+			Type:    "service.log",
+			Service: w.service,
+			Stream:  "stdout",
+			LogData: strings.Join(batch, "\n"),
+		})
+	}
+}
+
+// Write implements io.Writer. Buffers partial lines and enqueues complete
+// lines for async delivery to rigd.
+func (w *rigLogWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.buf.Write(p)
+
+	// Flush all complete lines.
+	for {
+		line, err := w.buf.ReadBytes('\n')
+		if err != nil {
+			// No newline found — put the partial line back.
+			w.buf.Write(line)
+			break
+		}
+		w.enqueue(string(bytes.TrimRight(line, "\n")))
+	}
+
+	return len(p), nil
+}
+
+// Flush sends any remaining buffered data and waits for the background
+// goroutine to finish delivering all queued lines.
+func (w *rigLogWriter) Flush() {
+	w.mu.Lock()
+	if w.buf.Len() > 0 {
+		w.enqueue(w.buf.String())
+		w.buf.Reset()
+	}
+	w.mu.Unlock()
+
+	close(w.ch)
+	<-w.done // wait for all lines to be posted
+}
+
+// enqueue sends a line to the background goroutine. Drops the line if the
+// channel is full (writer should never block the caller).
+func (w *rigLogWriter) enqueue(line string) {
+	if line == "" {
+		return
+	}
+	select {
+	case w.ch <- line:
+	default:
+		// channel full — drop line rather than block
+	}
+}

--- a/connect/log.go
+++ b/connect/log.go
@@ -1,0 +1,32 @@
+package connect
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+type logWriterKey struct{}
+
+// WithLogWriter returns a new context carrying the given io.Writer for
+// service logging. The rig client SDK sets this automatically for Func
+// services so that log output is captured in the event timeline.
+func WithLogWriter(ctx context.Context, w io.Writer) context.Context {
+	return context.WithValue(ctx, logWriterKey{}, w)
+}
+
+// LogWriter returns an io.Writer for service log output. When running as
+// a rig Func service, writes are shipped to the rigd event timeline. When
+// running outside of rig (production, local dev), returns os.Stdout.
+//
+// The returned writer works directly with Go's standard logging:
+//
+//	slog.New(slog.NewTextHandler(connect.LogWriter(ctx), nil))
+//	log.New(connect.LogWriter(ctx), "", 0)
+//	log.SetOutput(connect.LogWriter(ctx))
+func LogWriter(ctx context.Context) io.Writer {
+	if w, ok := ctx.Value(logWriterKey{}).(io.Writer); ok && w != nil {
+		return w
+	}
+	return os.Stdout
+}

--- a/examples/orderflow/cmd/orderflow/main.go
+++ b/examples/orderflow/cmd/orderflow/main.go
@@ -3,59 +3,17 @@ package main
 import (
 	"context"
 	"log"
-	"net/http"
 	"os"
 	"os/signal"
 
-	"github.com/matgreaves/rig/connect"
-	"github.com/matgreaves/rig/connect/httpx"
-	rigpgx "github.com/matgreaves/rig/connect/pgx"
-	"github.com/matgreaves/rig/connect/temporalx"
 	"github.com/matgreaves/rig/examples/orderflow"
-	"go.temporal.io/sdk/worker"
 )
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	if err := run(ctx); err != nil {
+	if err := orderflow.Run(ctx); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func run(ctx context.Context) error {
-	w, err := connect.ParseWiring(ctx)
-	if err != nil {
-		return err
-	}
-
-	pool, err := rigpgx.Connect(ctx, w.Egress("db"))
-	if err != nil {
-		return err
-	}
-	defer pool.Close()
-
-	tc, err := temporalx.Dial(w.Egress("temporal"))
-	if err != nil {
-		return err
-	}
-	defer tc.Close()
-
-	// Start Temporal worker.
-	wkr := worker.New(tc, "orders", worker.Options{})
-	wkr.RegisterWorkflow(orderflow.ProcessOrder)
-	wkr.RegisterActivity(&orderflow.Activities{Pool: pool})
-
-	if err := wkr.Start(); err != nil {
-		return err
-	}
-	defer wkr.Stop()
-
-	// Start HTTP server.
-	h := &orderflow.Handler{Pool: pool, Temporal: tc}
-	mux := http.NewServeMux()
-	h.Routes(mux)
-
-	return httpx.ListenAndServe(ctx, mux)
 }

--- a/examples/orderflow/handler.go
+++ b/examples/orderflow/handler.go
@@ -2,6 +2,7 @@ package orderflow
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 type Handler struct {
 	Pool     *pgxpool.Pool
 	Temporal client.Client
+	Log      *slog.Logger
 }
 
 // Routes registers all HTTP routes on the given mux.
@@ -56,6 +58,8 @@ func (h *Handler) createOrder(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	h.Log.Info("order created", "id", order.ID, "customer", order.Customer, "items", len(order.Items))
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)

--- a/examples/orderflow/run.go
+++ b/examples/orderflow/run.go
@@ -1,0 +1,64 @@
+package orderflow
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/matgreaves/rig/connect"
+	"github.com/matgreaves/rig/connect/httpx"
+	rigpgx "github.com/matgreaves/rig/connect/pgx"
+	"github.com/matgreaves/rig/connect/temporalx"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/worker"
+)
+
+// Run is the entrypoint for the orderflow service. It reads wiring from the
+// context, connects to Postgres and Temporal, starts a worker and HTTP server.
+//
+// Works identically as a rig.Func or compiled binary — the only difference
+// is how the context is provided.
+func Run(ctx context.Context) error {
+	w, err := connect.ParseWiring(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Set up structured logging — in rig tests, logs appear in the event
+	// timeline; in production, they go to stdout.
+	logger := slog.New(slog.NewTextHandler(connect.LogWriter(ctx), nil))
+
+	pool, err := rigpgx.Connect(ctx, w.Egress("db"))
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	tc, err := temporalx.Dial(w.Egress("temporal"), client.Options{
+		Logger: log.NewStructuredLogger(logger),
+	})
+	if err != nil {
+		return err
+	}
+	defer tc.Close()
+
+	logger.Info("connected", "db", w.Egress("db").Addr(), "temporal", w.Egress("temporal").Addr())
+
+	// Start Temporal worker — inherits the client's logger.
+	wkr := worker.New(tc, "orders", worker.Options{})
+	wkr.RegisterWorkflow(ProcessOrder)
+	wkr.RegisterActivity(&Activities{Pool: pool})
+
+	if err := wkr.Start(); err != nil {
+		return err
+	}
+	defer wkr.Stop()
+
+	// Start HTTP server.
+	h := &Handler{Pool: pool, Temporal: tc, Log: logger}
+	mux := http.NewServeMux()
+	h.Routes(mux)
+
+	return httpx.ListenAndServe(ctx, mux)
+}


### PR DESCRIPTION
## Summary

- **`connect.LogWriter(ctx)`** returns an `io.Writer` for service logging. When running as a `rig.Func`, writes are posted as `service.log` events to rigd's event timeline. Outside of rig, falls back to `os.Stdout`.
- Works directly with Go's standard logging: `slog.NewTextHandler(connect.LogWriter(ctx), nil)` or `log.New(connect.LogWriter(ctx), "", 0)`
- Writer is async (buffered channel + background goroutine) — `Write` never blocks on HTTP I/O
- Lines are batched naturally: bursts are joined into single events, matching how process stdout capture already works
- Server handles `service.log` client events via the existing `POST /environments/{id}/events` endpoint
- Extracts `orderflow.Run` so the example test exercises both `rig.Go` and `rig.Func` modes with the same test logic
- Logger is dependency-injected (no global `slog.SetDefault`), Temporal worker uses `log.NewStructuredLogger` for unified log output

## Test plan

- [x] `TestFuncLogWriter` — verifies Func logs appear in event timeline (JSONL)
- [x] `TestOrderFlow/Go` — compiled binary mode still works
- [x] `TestOrderFlow/Func` — in-process mode works with slog + Temporal logger wiring
- [x] `make test` — all modules pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)