### PR TITLE
Kill stale rigd on build, give init hooks full wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .PHONY: build test clean clean-bin clean-logs clean-cache
 
 # Build rigd with reproducible flags to ./bin/
+# Kills any running rigd so stale processes don't serve old code.
 build:
 	cd internal && CGO_ENABLED=0 go build -trimpath -buildvcs=false -o ../bin/rigd ./cmd/rigd
+	@pkill -f rigd 2>/dev/null || true
 
 # Build rigd, then run tests with RIG_BINARY pointing at it
 test: build

--- a/internal/server/eventlog.go
+++ b/internal/server/eventlog.go
@@ -74,10 +74,8 @@ type CallbackRequest struct {
 }
 
 // WiringContext provides resolved endpoint information to callbacks.
-// Contents vary by callback type:
-//   - prestart hook: Ingresses + Egresses + TempDir + EnvDir
-//   - init hook: Ingresses only + TempDir (no egresses)
-//   - custom type callbacks: type-specific
+// All hooks and start callbacks receive the full wiring: Ingresses,
+// Egresses, TempDir, and EnvDir.
 type WiringContext struct {
 	Ingresses  map[string]spec.Endpoint `json:"ingresses,omitempty"`
 	Egresses   map[string]spec.Endpoint `json:"egresses,omitempty"`


### PR DESCRIPTION
## Summary

- **Makefile**: `pkill rigd` after rebuilding the binary so stale processes don't serve old code during test runs
- **Init hooks**: now receive full wiring (ingresses + egresses), matching prestart hooks. There was no architectural reason to withhold egresses — removes the `includeEgresses` parameter from `dispatchCallback`

## Test plan

- [x] `make test` — all modules pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)