### PR TITLE
Add typed attribute registry in connect/

### DIFF
--- a/connect/attrs.go
+++ b/connect/attrs.go
@@ -1,0 +1,76 @@
+package connect
+
+import "fmt"
+
+// Attr is a typed attribute key for use with Endpoint.Attributes.
+// The type parameter T indicates the expected value type.
+// Use string(a) to get the raw key name.
+type Attr[T any] string
+
+// Get retrieves the attribute value from the endpoint.
+// Returns the zero value and false if the key is not present.
+// Panics if the key exists but has the wrong type — this indicates a
+// bug in the producer (server) or consumer (client helper).
+func (a Attr[T]) Get(ep Endpoint) (T, bool) {
+	v, ok := ep.Attributes[string(a)]
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	t, ok := v.(T)
+	if !ok {
+		panic(fmt.Sprintf("rig: attribute %q has type %T, want %T", string(a), v, t))
+	}
+	return t, true
+}
+
+// MustGet retrieves the attribute value, panicking if missing or wrong type.
+func (a Attr[T]) MustGet(ep Endpoint) T {
+	v, ok := a.Get(ep)
+	if !ok {
+		panic(fmt.Sprintf("rig: attribute %q not found", string(a)))
+	}
+	return v
+}
+
+// Set writes the attribute value into a map (typically Endpoint.Attributes).
+func (a Attr[T]) Set(m map[string]any, v T) {
+	m[string(a)] = v
+}
+
+// Well-known Postgres attributes.
+var (
+	PGHost     = Attr[string]("PGHOST")
+	PGPort     = Attr[string]("PGPORT")
+	PGUser     = Attr[string]("PGUSER")
+	PGPassword = Attr[string]("PGPASSWORD")
+	PGDatabase = Attr[string]("PGDATABASE")
+)
+
+// Well-known Temporal attributes.
+var (
+	TemporalAddress   = Attr[string]("TEMPORAL_ADDRESS")
+	TemporalNamespace = Attr[string]("TEMPORAL_NAMESPACE")
+)
+
+// Well-known Redis attributes.
+var (
+	RedisURL = Attr[string]("REDIS_URL")
+)
+
+// Cross-cutting attributes.
+var (
+	// Secure indicates the endpoint requires TLS or equivalent.
+	Secure = Attr[bool]("SECURE")
+)
+
+// PostgresDSN builds a Postgres connection string from endpoint attributes.
+// Uses PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE with sslmode=disable.
+func PostgresDSN(ep Endpoint) string {
+	host, _ := PGHost.Get(ep)
+	port, _ := PGPort.Get(ep)
+	user, _ := PGUser.Get(ep)
+	pass, _ := PGPassword.Get(ep)
+	db, _ := PGDatabase.Get(ep)
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", user, pass, host, port, db)
+}

--- a/connect/attrs_test.go
+++ b/connect/attrs_test.go
@@ -1,0 +1,128 @@
+package connect
+
+import "testing"
+
+func TestAttr_Get(t *testing.T) {
+	ep := Endpoint{
+		Attributes: map[string]any{
+			"PGHOST": "127.0.0.1",
+			"COUNT":  42,
+		},
+	}
+
+	// Present, correct type.
+	v, ok := PGHost.Get(ep)
+	if !ok || v != "127.0.0.1" {
+		t.Errorf("PGHost.Get = (%q, %v), want (127.0.0.1, true)", v, ok)
+	}
+
+	// Missing key.
+	v, ok = PGPort.Get(ep)
+	if ok || v != "" {
+		t.Errorf("PGPort.Get = (%q, %v), want ('', false)", v, ok)
+	}
+
+}
+
+func TestAttr_Get_WrongType_Panics(t *testing.T) {
+	ep := Endpoint{
+		Attributes: map[string]any{
+			"COUNT": 42,
+		},
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Get did not panic on wrong type")
+		}
+	}()
+	Attr[string]("COUNT").Get(ep)
+}
+
+func TestAttr_Get_NilAttributes(t *testing.T) {
+	ep := Endpoint{}
+	v, ok := PGHost.Get(ep)
+	if ok || v != "" {
+		t.Errorf("PGHost.Get on nil attrs = (%q, %v), want ('', false)", v, ok)
+	}
+}
+
+func TestAttr_MustGet(t *testing.T) {
+	ep := Endpoint{
+		Attributes: map[string]any{
+			"PGHOST": "localhost",
+		},
+	}
+	if v := PGHost.MustGet(ep); v != "localhost" {
+		t.Errorf("MustGet = %q, want localhost", v)
+	}
+}
+
+func TestAttr_MustGet_Panics(t *testing.T) {
+	ep := Endpoint{}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("MustGet did not panic on missing attribute")
+		}
+	}()
+	PGHost.MustGet(ep)
+}
+
+func TestAttr_Set(t *testing.T) {
+	m := make(map[string]any)
+	PGHost.Set(m, "10.0.0.1")
+	if m["PGHOST"] != "10.0.0.1" {
+		t.Errorf("Set: m[PGHOST] = %v, want 10.0.0.1", m["PGHOST"])
+	}
+}
+
+func TestAttr_String(t *testing.T) {
+	if s := string(PGHost); s != "PGHOST" {
+		t.Errorf("string(PGHost) = %q, want PGHOST", s)
+	}
+	if s := string(TemporalAddress); s != "TEMPORAL_ADDRESS" {
+		t.Errorf("string(TemporalAddress) = %q, want TEMPORAL_ADDRESS", s)
+	}
+}
+
+func TestAttr_Bool(t *testing.T) {
+	ep := Endpoint{
+		Attributes: map[string]any{
+			"SECURE": true,
+		},
+	}
+	v, ok := Secure.Get(ep)
+	if !ok || !v {
+		t.Errorf("Secure.Get = (%v, %v), want (true, true)", v, ok)
+	}
+
+	// Missing returns false (zero value).
+	ep2 := Endpoint{}
+	v, ok = Secure.Get(ep2)
+	if ok || v {
+		t.Errorf("Secure.Get on empty = (%v, %v), want (false, false)", v, ok)
+	}
+}
+
+func TestPostgresDSN(t *testing.T) {
+	ep := Endpoint{
+		Attributes: map[string]any{
+			"PGHOST":     "127.0.0.1",
+			"PGPORT":     "5432",
+			"PGUSER":     "postgres",
+			"PGPASSWORD": "postgres",
+			"PGDATABASE": "testdb",
+		},
+	}
+	want := "postgres://postgres:postgres@127.0.0.1:5432/testdb?sslmode=disable"
+	if got := PostgresDSN(ep); got != want {
+		t.Errorf("PostgresDSN = %q, want %q", got, want)
+	}
+}
+
+func TestPostgresDSN_Missing(t *testing.T) {
+	ep := Endpoint{}
+	want := "postgres://:@:/?sslmode=disable"
+	if got := PostgresDSN(ep); got != want {
+		t.Errorf("PostgresDSN = %q, want %q", got, want)
+	}
+}

--- a/connect/pgx/pgx.go
+++ b/connect/pgx/pgx.go
@@ -14,7 +14,6 @@ package pgx
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // register "pgx" database/sql driver
@@ -24,12 +23,7 @@ import (
 // DSN builds a Postgres connection string from endpoint attributes.
 // Uses PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE with sslmode=disable.
 func DSN(ep connect.Endpoint) string {
-	host := ep.Attr("PGHOST")
-	port := ep.Attr("PGPORT")
-	user := ep.Attr("PGUSER")
-	pass := ep.Attr("PGPASSWORD")
-	db := ep.Attr("PGDATABASE")
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", user, pass, host, port, db)
+	return connect.PostgresDSN(ep)
 }
 
 // Connect returns a pgx connection pool from a rig Postgres endpoint.

--- a/connect/temporalx/temporalx.go
+++ b/connect/temporalx/temporalx.go
@@ -18,12 +18,14 @@ import (
 
 // Addr extracts the TEMPORAL_ADDRESS attribute from the endpoint.
 func Addr(ep connect.Endpoint) string {
-	return ep.Attr("TEMPORAL_ADDRESS")
+	v, _ := connect.TemporalAddress.Get(ep)
+	return v
 }
 
 // Namespace extracts the TEMPORAL_NAMESPACE attribute from the endpoint.
 func Namespace(ep connect.Endpoint) string {
-	return ep.Attr("TEMPORAL_NAMESPACE")
+	v, _ := connect.TemporalNamespace.Get(ep)
+	return v
 }
 
 // Dial creates a Temporal client from a rig endpoint.

--- a/internal/server/service/postgres.go
+++ b/internal/server/service/postgres.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/matgreaves/rig/connect"
 	"github.com/matgreaves/rig/internal/server/artifact"
 	"github.com/matgreaves/rig/internal/server/dockerutil"
 	"github.com/matgreaves/rig/internal/server/ready"
@@ -52,11 +53,11 @@ func (Postgres) Publish(_ context.Context, params PublishParams) (map[string]spe
 		if ep.Attributes == nil {
 			ep.Attributes = make(map[string]any)
 		}
-		ep.Attributes["PGHOST"] = ep.Host
-		ep.Attributes["PGPORT"] = strconv.Itoa(ep.Port)
-		ep.Attributes["PGDATABASE"] = params.ServiceName
-		ep.Attributes["PGUSER"] = postgresDefaultUser
-		ep.Attributes["PGPASSWORD"] = postgresDefaultPassword
+		connect.PGHost.Set(ep.Attributes, ep.Host)
+		connect.PGPort.Set(ep.Attributes, strconv.Itoa(ep.Port))
+		connect.PGDatabase.Set(ep.Attributes, params.ServiceName)
+		connect.PGUser.Set(ep.Attributes, postgresDefaultUser)
+		connect.PGPassword.Set(ep.Attributes, postgresDefaultPassword)
 		ep.AddressAttrs = map[string]spec.AddrAttr{
 			"PGHOST": spec.AttrHost,
 			"PGPORT": spec.AttrPort,

--- a/internal/server/service/temporal.go
+++ b/internal/server/service/temporal.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/matgreaves/rig/connect"
 	"github.com/matgreaves/rig/internal/server/artifact"
 	"github.com/matgreaves/rig/internal/spec"
 	"github.com/matgreaves/run"
@@ -51,8 +52,8 @@ func (Temporal) Publish(_ context.Context, params PublishParams) (map[string]spe
 		if ep.Attributes == nil {
 			ep.Attributes = make(map[string]any)
 		}
-		ep.Attributes["TEMPORAL_ADDRESS"] = fmt.Sprintf("%s:%d", ep.Host, ep.Port)
-		ep.Attributes["TEMPORAL_NAMESPACE"] = cfg.Namespace
+		connect.TemporalAddress.Set(ep.Attributes, fmt.Sprintf("%s:%d", ep.Host, ep.Port))
+		connect.TemporalNamespace.Set(ep.Attributes, cfg.Namespace)
 		ep.AddressAttrs = map[string]spec.AddrAttr{
 			"TEMPORAL_ADDRESS": spec.AttrHostPort,
 		}


### PR DESCRIPTION
## Summary

- Introduce `Attr[T]` generic type in `connect/attrs.go` for typed Get/Set access to `Endpoint.Attributes`, replacing hardcoded string literals across producers and consumers
- `Get` panics on type mismatch (always a producer/consumer bug), returns `(zero, false)` on missing key
- Well-known vars for Postgres (`PGHost`, `PGPort`, `PGUser`, `PGPassword`, `PGDatabase`), Temporal (`TemporalAddress`, `TemporalNamespace`), Redis (`RedisURL`), and a cross-cutting `Secure Attr[bool]`
- Move `PostgresDSN` into `connect/` (stdlib-only) so it can be shared without pulling in the pgx dependency
- Update `connect/pgx`, `connect/temporalx`, and `internal/server/service` to use typed attrs

## Test plan

- [x] `connect/attrs_test.go` — 10 unit tests covering Get (present, missing, nil attrs, wrong type panic), MustGet (success, panic), Set, string conversion, bool type, PostgresDSN
- [x] `make test` passes — root, internal, and examples modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)