### PR TITLE
Auto-download rigd binary from GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release rigd
+
+on:
+  push:
+    tags:
+      - "rigd/v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: internal/go.mod
+
+      - name: Build all platforms
+        run: make build-all
+
+      - name: Package
+        run: |
+          for dir in bin/*/; do
+            platform=$(basename "$dir")
+            tar -czf "rigd-${platform}.tar.gz" -C "$dir" rigd
+          done
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --generate-notes \
+            rigd-*.tar.gz
+
+  bump-sdk:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#rigd/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Update client/version.go
+        run: |
+          sed -i 's/const RigdVersion = ".*"/const RigdVersion = "${{ steps.version.outputs.version }}"/' client/version.go
+
+      - name: Commit to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add client/version.go
+          git diff --cached --quiet && exit 0
+          git commit -m "Bump RigdVersion to ${{ steps.version.outputs.version }}"
+          git push origin HEAD:main

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-.PHONY: build test clean clean-bin clean-logs clean-cache
+.PHONY: build build-all test clean clean-bin clean-logs clean-cache
 
-# Build rigd with reproducible flags to ./bin/
+PLATFORMS := linux-amd64 linux-arm64 darwin-amd64 darwin-arm64
+
+# Build rigd for the host platform to ./bin/
 # Kills any running rigd so stale processes don't serve old code.
 build:
 	cd internal && CGO_ENABLED=0 go build -trimpath -buildvcs=false -o ../bin/rigd ./cmd/rigd
 	@pkill -f rigd 2>/dev/null || true
+
+# Build rigd for all release platforms to ./bin/{os}-{arch}/rigd
+build-all:
+	$(foreach p,$(PLATFORMS),\
+		GOOS=$(word 1,$(subst -, ,$(p))) GOARCH=$(word 2,$(subst -, ,$(p))) CGO_ENABLED=0 \
+		go build -C internal -trimpath -buildvcs=false -o ../bin/$(p)/rigd ./cmd/rigd ;)
 
 # Build rigd, then run tests with RIG_BINARY pointing at it
 test: build

--- a/client/download.go
+++ b/client/download.go
@@ -1,0 +1,88 @@
+package rig
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// downloadURL returns the GitHub Releases URL for a rigd binary.
+func downloadURL(version string) string {
+	return fmt.Sprintf(
+		"https://github.com/matgreaves/rig/releases/download/rigd/v%s/rigd-%s-%s.tar.gz",
+		version, runtime.GOOS, runtime.GOARCH,
+	)
+}
+
+// downloadBinary downloads a tar.gz archive from url, extracts the "rigd"
+// binary, and writes it to destPath. Uses a temp file + rename for atomicity.
+func downloadBinary(url, destPath string) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+
+		if filepath.Base(hdr.Name) != "rigd" || hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		// Write to temp file then rename for atomicity.
+		tmp, err := os.CreateTemp(filepath.Dir(destPath), "rigd-download-*")
+		if err != nil {
+			return fmt.Errorf("create temp file: %w", err)
+		}
+		tmpPath := tmp.Name()
+
+		if _, err := io.Copy(tmp, tr); err != nil {
+			tmp.Close()
+			os.Remove(tmpPath)
+			return fmt.Errorf("extract binary: %w", err)
+		}
+		if err := tmp.Chmod(0o755); err != nil {
+			tmp.Close()
+			os.Remove(tmpPath)
+			return fmt.Errorf("chmod binary: %w", err)
+		}
+		if err := tmp.Close(); err != nil {
+			os.Remove(tmpPath)
+			return fmt.Errorf("close temp file: %w", err)
+		}
+		if err := os.Rename(tmpPath, destPath); err != nil {
+			os.Remove(tmpPath)
+			return fmt.Errorf("rename binary: %w", err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("rigd binary not found in archive %s", url)
+}

--- a/client/download_test.go
+++ b/client/download_test.go
@@ -1,0 +1,168 @@
+package rig
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDownloadURL(t *testing.T) {
+	url := downloadURL("0.1.0")
+	want := "https://github.com/matgreaves/rig/releases/download/rigd/v0.1.0/rigd-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz"
+	if url != want {
+		t.Errorf("downloadURL:\n  got  %s\n  want %s", url, want)
+	}
+}
+
+// makeTarGz creates a tar.gz archive containing a single file named "rigd"
+// with the given content.
+func makeTarGz(t *testing.T, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "rigd",
+		Size: int64(len(content)),
+		Mode: 0o755,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestDownloadBinary(t *testing.T) {
+	payload := []byte("#!/bin/sh\necho hello\n")
+	archive := makeTarGz(t, payload)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "v0.1.0", "rigd")
+
+	if err := downloadBinary(srv.URL+"/rigd.tar.gz", dest); err != nil {
+		t.Fatalf("downloadBinary: %v", err)
+	}
+
+	// Verify file exists with correct content.
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read extracted binary: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("content mismatch:\n  got  %q\n  want %q", got, payload)
+	}
+
+	// Verify permissions.
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm&0o111 == 0 {
+		t.Errorf("binary not executable: %o", perm)
+	}
+}
+
+func TestDownloadBinaryCreatesDirectory(t *testing.T) {
+	payload := []byte("binary")
+	archive := makeTarGz(t, payload)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	// Nested path that doesn't exist yet.
+	dest := filepath.Join(t.TempDir(), "deep", "nested", "rigd")
+
+	if err := downloadBinary(srv.URL+"/rigd.tar.gz", dest); err != nil {
+		t.Fatalf("downloadBinary: %v", err)
+	}
+
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("binary not found: %v", err)
+	}
+}
+
+func TestDownloadBinaryHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "rigd")
+	err := downloadBinary(srv.URL+"/rigd.tar.gz", dest)
+	if err == nil {
+		t.Fatal("expected error for HTTP 404")
+	}
+}
+
+func TestDownloadBinaryMissingEntry(t *testing.T) {
+	// Archive with a different file name — "not-rigd".
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	tw.WriteHeader(&tar.Header{Name: "not-rigd", Size: 4, Mode: 0o755})
+	tw.Write([]byte("data"))
+	tw.Close()
+	gw.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(buf.Bytes())
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "rigd")
+	err := downloadBinary(srv.URL+"/rigd.tar.gz", dest)
+	if err == nil {
+		t.Fatal("expected error for missing rigd entry")
+	}
+}
+
+func TestDownloadBinaryNoTempFileLeftover(t *testing.T) {
+	payload := []byte("binary")
+	archive := makeTarGz(t, payload)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "rigd")
+
+	if err := downloadBinary(srv.URL+"/rigd.tar.gz", dest); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only "rigd" should exist in dir — no temp file leftovers.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "rigd" {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("unexpected files in dir: %v", names)
+	}
+}

--- a/client/version.go
+++ b/client/version.go
@@ -1,0 +1,6 @@
+package rig
+
+// RigdVersion is the rigd server version this SDK targets.
+// Tagged separately as rigd/v{RigdVersion} in git.
+// Bump when rigd changes. Client-only changes don't require a bump.
+const RigdVersion = "0.1.0"


### PR DESCRIPTION
## Summary

- Add `--addr-file` flag to rigd so the client can specify per-version addr file paths
- SDK embeds a target rigd version (`RigdVersion` const) and auto-downloads the correct platform binary from GitHub Releases when none is found locally
- Per-version addr/lock files (`rigd-v0.1.0.addr`) allow multiple SDK versions to coexist; `RIG_BINARY` override keeps unversioned paths for dev/CI
- GitHub Actions workflow builds linux/darwin × amd64/arm64 on `rigd/v*` tags and commits the version bump to main after release

## Test plan

- [x] `make test` passes — `RIG_BINARY` path works as before
- [x] `TestAddrFileFlag` — custom addr file written and cleaned up on shutdown
- [x] `TestDownloadBinary*` — httptest-based extraction, permissions, atomicity, error cases
- [ ] Tag `rigd/v0.0.1-test`, verify workflow builds 4 archives and bumps `client/version.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)