### PR TITLE
Add README, LICENSE, and agents guide

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mat Greaves
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,278 @@
+# rig
+
+Test environment orchestrator for Go. Define multi-service environments in code — Postgres, Temporal, Docker containers, Go binaries — and rig builds, starts, wires, and tears them down automatically.
+
+```go
+func TestAPI(t *testing.T) {
+    env := rig.Up(t, rig.Services{
+        "db":       rig.Postgres().InitSQLDir("./migrations"),
+        "temporal": rig.Temporal(),
+        "api":      rig.Go("./cmd/api").Egress("db").Egress("temporal"),
+    })
+
+    client := httpx.New(env.Endpoint("api"))
+    resp, _ := client.Get("/health")
+    // ...
+}
+```
+
+No YAML. No manual port wiring. No cleanup code. Services start in dependency order, health checks pass, and you get back typed endpoints.
+
+## How it works
+
+A standalone server (`rigd`) manages service lifecycles. The Go SDK sends a declarative spec over HTTP, then streams events via SSE until the environment is ready. `rigd` handles building Go binaries, pulling Docker images, allocating ports, running health checks, and resolving wiring between services.
+
+The SDK auto-starts `rigd` on first use — no separate install step needed. The binary is downloaded from GitHub Releases and cached in `~/.rig/bin/`.
+
+## Install
+
+```bash
+go get github.com/matgreaves/rig
+```
+
+The root module has **zero external dependencies**. Your `go.sum` stays clean.
+
+## Quickstart
+
+```go
+package myapp_test
+
+import (
+    "testing"
+
+    rig "github.com/matgreaves/rig/client"
+    "github.com/matgreaves/rig/connect/httpx"
+)
+
+func TestMyApp(t *testing.T) {
+    env := rig.Up(t, rig.Services{
+        "db":  rig.Postgres(),
+        "api": rig.Go("./cmd/api").Egress("db"),
+    })
+
+    api := httpx.New(env.Endpoint("api"))
+    resp, err := api.Get("/health")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if resp.StatusCode != 200 {
+        t.Fatalf("status %d", resp.StatusCode)
+    }
+}
+```
+
+Run with `go test`:
+
+```bash
+go test ./...
+```
+
+On first run, `rigd` is downloaded automatically. Postgres starts in Docker, the Go binary is built and launched with the right connection string, and everything tears down when the test finishes.
+
+## Service types
+
+### Go binary
+
+Builds and runs a Go module. Default HTTP ingress.
+
+```go
+rig.Go("./cmd/api").
+    Egress("db").
+    Args("--verbose")
+```
+
+### In-process function
+
+Runs a Go function in the test process. Same wiring interface as a binary — swap between `rig.Go` and `rig.Func` freely.
+
+```go
+rig.Func(myapp.Run).
+    Egress("db").
+    Egress("temporal")
+```
+
+### Docker container
+
+Runs any Docker image. Set the container port with `.Port()`.
+
+```go
+rig.Container("redis:7").Port(6379)
+rig.Container("nginx:alpine").Port(80).Env("NGINX_HOST", "localhost")
+```
+
+### Postgres
+
+Managed Postgres container with automatic database creation and SQL init.
+
+```go
+rig.Postgres()
+rig.Postgres().InitSQLDir("./migrations")
+rig.Postgres().InitSQL("CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT)")
+```
+
+### Temporal
+
+Managed Temporal dev server. Downloads the CLI binary on first use.
+
+```go
+rig.Temporal()
+rig.Temporal().Version("1.5.1").Namespace("my-ns")
+```
+
+### Pre-built binary
+
+Runs any executable.
+
+```go
+rig.Process("/usr/local/bin/myservice").
+    Egress("db")
+```
+
+## Wiring
+
+Services declare dependencies with `.Egress()`. Rig resolves the graph, starts services in order, and passes connection details as environment variables.
+
+```go
+rig.Services{
+    "db":       rig.Postgres(),
+    "cache":    rig.Container("redis:7").Port(6379),
+    "api":      rig.Go("./cmd/api").Egress("db").Egress("cache"),
+    "worker":   rig.Go("./cmd/worker").Egress("db").Egress("temporal").NoIngress(),
+    "temporal": rig.Temporal(),
+}
+```
+
+Each service receives its egress endpoints as environment variables. For Go services, use the `connect` package to read wiring:
+
+```go
+// In your service's main():
+w, err := connect.ParseWiring(ctx)
+dbEndpoint := w.Egress("db")  // connect.Endpoint with Host, Port, Attributes
+```
+
+## Endpoints and attributes
+
+`env.Endpoint("service")` returns a `connect.Endpoint` with `Host`, `Port`, `Protocol`, and typed `Attributes`.
+
+Built-in services publish well-known attributes:
+
+```go
+// Postgres
+ep := env.Endpoint("db")
+dsn := connect.PostgresDSN(ep) // "postgres://postgres:postgres@127.0.0.1:54321/mydb"
+
+// Or use typed attributes directly
+host := connect.PGHost.MustGet(ep)
+port := connect.PGPort.MustGet(ep)
+
+// Temporal
+ep := env.Endpoint("temporal")
+addr := connect.TemporalAddress.MustGet(ep)   // "127.0.0.1:7233"
+ns := connect.TemporalNamespace.MustGet(ep)    // "default"
+```
+
+## Client helpers
+
+Optional sub-modules provide typed clients that work with rig endpoints. Each is a separate Go module to isolate heavy dependencies.
+
+### HTTP — `connect/httpx`
+
+```go
+import "github.com/matgreaves/rig/connect/httpx"
+
+api := httpx.New(env.Endpoint("api"))
+resp, err := api.Get("/users")
+resp, err = api.Post("/users", "application/json", body)
+```
+
+### Postgres — `connect/pgx`
+
+```go
+import "github.com/matgreaves/rig/connect/pgx"
+
+pool, err := pgx.Connect(ctx, env.Endpoint("db"))
+db, err := pgx.OpenDB(env.Endpoint("db"))  // *sql.DB
+```
+
+### Temporal — `connect/temporalx`
+
+```go
+import "github.com/matgreaves/rig/connect/temporalx"
+
+client, err := temporalx.Dial(env.Endpoint("temporal"))
+```
+
+## Hooks
+
+Run setup code at specific lifecycle points:
+
+```go
+rig.Postgres().InitHook(func(ctx context.Context, w rig.Wiring) error {
+    // Runs after health checks pass, before service is marked ready.
+    // Receives full wiring.
+    return runMigrations(w.Ingress())
+})
+
+rig.Go("./cmd/api").PrestartHook(func(ctx context.Context, w rig.Wiring) error {
+    // Runs after egresses are resolved, before the process starts.
+    // Receives full wiring (ingresses + egresses).
+    return seedTestData(w.Egress("db"))
+})
+
+// SQL init hooks run server-side via docker exec — no SQL driver needed:
+rig.Postgres().InitSQL("INSERT INTO users (name) VALUES ('alice')")
+
+// Exec hooks run commands inside containers:
+rig.Container("redis:7").Port(6379).Exec("redis-cli", "SET", "key", "value")
+```
+
+## Temp directories
+
+Every service gets two scratch directories, available via `Wiring`:
+
+- **`w.TempDir`** — per-service isolated workspace. Each service gets its own. Use it for config files, generated artifacts, or anything a single service needs.
+- **`w.EnvDir`** — per-environment shared directory. All services in the same environment can read and write here. Use it for cross-service coordination (e.g. shared fixtures, config one service writes and another reads).
+
+Both are created before services start and cleaned up on teardown.
+
+A common pattern is writing config in a prestart hook and referencing it in args with `${RIG_TEMP_DIR}`:
+
+```go
+rig.Go("./cmd/api").
+    Args("-c", "${RIG_TEMP_DIR}/config.json").
+    PrestartHook(func(ctx context.Context, w rig.Wiring) error {
+        cfg := buildConfig(w.Egress("db"))
+        return os.WriteFile(
+            filepath.Join(w.TempDir, "config.json"), cfg, 0o644,
+        )
+    })
+```
+
+## Options
+
+```go
+rig.Up(t, services,
+    rig.WithTimeout(5*time.Minute),   // max startup wait (default: 2m)
+    rig.WithServer("http://..."),      // explicit rigd URL (default: auto-start)
+    rig.WithoutObserve(),              // disable traffic proxying
+)
+```
+
+## Modules
+
+| Module | Import path | Purpose |
+|--------|-------------|---------|
+| Root | `github.com/matgreaves/rig` | SDK + shared types. Zero deps. |
+| `connect/httpx` | `github.com/matgreaves/rig/connect/httpx` | HTTP client/server helpers |
+| `connect/pgx` | `github.com/matgreaves/rig/connect/pgx` | Postgres client (`pgxpool`, `*sql.DB`) |
+| `connect/temporalx` | `github.com/matgreaves/rig/connect/temporalx` | Temporal client helper |
+
+Server internals live in `internal/` and cannot be imported.
+
+## Agentic coding
+
+If you use an agentic coding tool (Claude Code, Cursor, Copilot), include [`agents-guide.md`](agents-guide.md) in your project context.
+
+## License
+
+MIT

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -1,0 +1,146 @@
+# rig — Agents Guide
+
+Test environment orchestrator for Go. A standalone server (`rigd`) manages service lifecycles; the Go SDK defines environments declaratively in test code.
+
+## Quick reference
+
+```go
+import rig "github.com/matgreaves/rig/client"
+
+env := rig.Up(t, rig.Services{
+    "db":       rig.Postgres().InitSQLDir("./migrations"),
+    "temporal": rig.Temporal(),
+    "api":      rig.Go("./cmd/api").Egress("db").Egress("temporal"),
+})
+ep := env.Endpoint("api") // connect.Endpoint{Host, Port, Protocol, Attributes}
+```
+
+`rig.Up` blocks until all services are healthy and registers `t.Cleanup` for teardown. `rigd` is auto-downloaded on first use.
+
+## Module structure
+
+| Import | Purpose | Deps |
+|--------|---------|------|
+| `github.com/matgreaves/rig/client` | SDK: `Up`, `TryUp`, service builders | Zero |
+| `github.com/matgreaves/rig/connect` | Shared types: `Endpoint`, `Wiring`, `ParseWiring`, typed `Attr[T]` | Zero |
+| `github.com/matgreaves/rig/connect/httpx` | HTTP client/server from endpoints | Zero |
+| `github.com/matgreaves/rig/connect/pgx` | `pgxpool.Pool` / `*sql.DB` from endpoint | pgx/v5 |
+| `github.com/matgreaves/rig/connect/temporalx` | Temporal client from endpoint | Temporal SDK |
+
+Root module has zero external dependencies. `connect/pgx` and `connect/temporalx` are separate Go modules to isolate heavy deps.
+
+## Service types
+
+| Constructor | What it runs | Default ingress |
+|-------------|-------------|-----------------|
+| `rig.Go("./cmd/api")` | Builds & runs Go module | HTTP |
+| `rig.Func(myapp.Run)` | Runs function in test process | HTTP |
+| `rig.Container("redis:7").Port(6379)` | Docker container | HTTP |
+| `rig.Process("/path/to/bin")` | Pre-built binary | HTTP |
+| `rig.Postgres()` | Managed Postgres container | Postgres (TCP) |
+| `rig.Temporal()` | Managed Temporal dev server | gRPC |
+
+All builders use method chaining: `.Egress("name")`, `.NoIngress()`, `.Ingress("name", def)`, `.Args(...)`, `.InitHook(fn)`, `.PrestartHook(fn)`.
+
+## Wiring
+
+Services declare dependencies with `.Egress("service")`. Rig resolves the dependency graph, starts services in order, and passes connection details.
+
+**In services** — use `connect.ParseWiring(ctx)` to read wiring:
+```go
+w, _ := connect.ParseWiring(ctx)
+dbEp := w.Egress("db")       // connect.Endpoint
+addr := dbEp.Addr()           // "host:port"
+dsn := connect.PostgresDSN(dbEp)
+```
+
+**In tests** — use `env.Endpoint("service")`:
+```go
+ep := env.Endpoint("api")
+client := httpx.New(ep)
+```
+
+## Typed attributes
+
+Built-in services publish well-known attributes on their endpoints:
+
+```go
+// Postgres
+connect.PGHost.MustGet(ep)      // string
+connect.PGPort.MustGet(ep)      // string
+connect.PGDatabase.MustGet(ep)  // string
+connect.PostgresDSN(ep)         // full DSN string
+
+// Temporal
+connect.TemporalAddress.MustGet(ep)    // "host:port"
+connect.TemporalNamespace.MustGet(ep)  // "default"
+```
+
+Define custom attributes with `connect.Attr[T]{Name: "MY_ATTR"}`.
+
+## Hooks
+
+```go
+// After health checks, before marked ready. Receives full wiring.
+.InitHook(func(ctx context.Context, w rig.Wiring) error { ... })
+
+// After egresses resolved, before process starts. Receives full wiring.
+.PrestartHook(func(ctx context.Context, w rig.Wiring) error { ... })
+
+// SQL init (server-side, no driver needed):
+rig.Postgres().InitSQL("CREATE TABLE ...")
+rig.Postgres().InitSQLDir("./migrations")
+
+// Exec inside container (server-side):
+.Exec("redis-cli", "SET", "key", "value")
+```
+
+## Temp directories
+
+Available on `Wiring`:
+
+- `w.TempDir` — per-service isolated workspace (config, artifacts)
+- `w.EnvDir` — per-environment shared directory (cross-service coordination)
+
+Args support `${RIG_TEMP_DIR}` expansion:
+```go
+rig.Go("./cmd/api").Args("-c", "${RIG_TEMP_DIR}/config.json").
+    PrestartHook(func(ctx context.Context, w rig.Wiring) error {
+        return os.WriteFile(filepath.Join(w.TempDir, "config.json"), cfg, 0o644)
+    })
+```
+
+## Options
+
+```go
+rig.Up(t, services,
+    rig.WithTimeout(5*time.Minute),  // default: 2m
+    rig.WithServer("http://..."),     // default: auto-start rigd
+    rig.WithoutObserve(),             // disable traffic proxying
+)
+```
+
+## Build & test (for rig contributors)
+
+```bash
+make build   # Build rigd to ./bin/rigd
+make test    # Build + run all tests
+make clean   # Remove artifacts
+```
+
+Five Go modules: root `go.mod`, `internal/go.mod`, `connect/temporalx/go.mod`, `connect/pgx/go.mod`, `examples/go.mod`. Always use `make test` — it sets `RIG_BINARY` and builds `rigd` first.
+
+## Key files
+
+- `client/rig.go` — `Up`, `TryUp`, `EnsureServer`, core types
+- `client/services.go` — `Go`, `Func`, `Process`, `Custom` builders
+- `client/container.go` — `Container` builder
+- `client/postgres.go` — `Postgres` builder
+- `client/temporal.go` — `Temporal` builder
+- `client/environment.go` — `Environment`, `Endpoint()` lookup
+- `connect/wiring.go` — `Wiring`, `ParseWiring`
+- `connect/attrs.go` — `Attr[T]`, well-known attributes (`PGHost`, `TemporalAddress`, etc.)
+- `connect/httpx/client.go` — `httpx.New`, HTTP client helpers
+- `connect/httpx/server.go` — `httpx.ListenAndServe` for services
+- `internal/server/` — rigd server (not importable by consumers)
+- `examples/orderflow/` — full example: Postgres + Temporal + HTTP API


### PR DESCRIPTION
## Summary
- Add MIT LICENSE
- Add README with quickstart, service types, wiring, hooks, and module overview
- Add agents-guide.md for agentic coding tool context

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)