### PR TITLE
Fix proxy port race in parallel tests

### DIFF
--- a/internal/server/ports.go
+++ b/internal/server/ports.go
@@ -2,17 +2,28 @@ package server
 
 import (
 	"fmt"
+	"math/big"
+	"math/rand/v2"
 	"net"
 	"sync"
 )
 
-// PortAllocator allocates random OS-assigned ports and tracks which ports
-// belong to which environment instance. This prevents the same rigd from
-// handing out a port that is already in use by another active environment.
+const (
+	portBase  = 0x2000 // 8192
+	portCount = 0x8000 - portBase // 24576
+)
+
+// PortAllocator allocates ports using a prime-stepping strategy that spreads
+// allocations across the port range, minimising collisions in parallel tests.
+// Ports are returned as open net.Listeners — callers that need zero TOCTOU
+// (proxies) can use the listener directly; callers that need a raw port number
+// close the listener and use the port.
 type PortAllocator struct {
 	mu        sync.Mutex
 	allocated map[int]string   // port → instance ID
 	byInstance map[string][]int // instance ID → ports (reverse index for O(k) release)
+	offset     uint64
+	step       uint64 // random prime
 }
 
 // NewPortAllocator creates an empty port allocator.
@@ -20,61 +31,67 @@ func NewPortAllocator() *PortAllocator {
 	return &PortAllocator{
 		allocated:  make(map[int]string),
 		byInstance: make(map[string][]int),
+		offset:     rand.Uint64N(portCount),
+		step:       randomPrime(portCount),
 	}
 }
 
-// Allocate reserves n random ports for the given instance. It binds to :0
-// to let the OS assign free ports, records them, then closes the listeners
-// and returns the ports.
-//
-// There is a small TOCTOU window between closing the listener and the
-// service actually binding the port. In practice this is negligible.
-func (a *PortAllocator) Allocate(instanceID string, n int) ([]int, error) {
+// Allocate reserves n ports for the given instance. It steps through the port
+// range by a random prime, trying net.Listen on each candidate. Listeners are
+// returned open — the caller decides whether to keep them (proxy) or close
+// them (service port).
+func (a *PortAllocator) Allocate(instanceID string, n int) ([]net.Listener, error) {
 	if n <= 0 {
 		return nil, nil
 	}
 
-	listeners := make([]net.Listener, 0, n)
-	ports := make([]int, 0, n)
-
-	// Open all listeners first to get guaranteed-unique ports from the OS.
-	for range n {
-		ln, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			// Clean up any listeners we already opened.
-			for _, l := range listeners {
-				l.Close()
-			}
-			return nil, fmt.Errorf("allocate port: %w", err)
-		}
-		listeners = append(listeners, ln)
-		ports = append(ports, ln.Addr().(*net.TCPAddr).Port)
-	}
-
-	// Close all listeners so the ports are available for services.
-	for _, ln := range listeners {
-		ln.Close()
-	}
-
-	// Record the allocation. Check all ports before writing any to avoid
-	// partial state if a collision is detected.
+	// Lock held for the full loop including net.Listen calls. This serialises
+	// concurrent Allocate callers but n is small (1–5) and listens are on
+	// localhost, so the hold time is negligible in practice.
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	for _, port := range ports {
-		if existingID, ok := a.allocated[port]; ok {
-			// Extremely unlikely — the OS just gave us this port.
-			// Defensive check in case the OS reuses a port from a
-			// recently-released but not-yet-cleaned-up instance.
-			return nil, fmt.Errorf("port %d already allocated to instance %q", port, existingID)
+	listeners := make([]net.Listener, 0, n)
+	ports := make([]int, 0, n)
+
+	cleanup := func() {
+		for _, ln := range listeners {
+			ln.Close()
 		}
 	}
+
+	for range n {
+		found := false
+		for range portCount {
+			port := portBase + int(a.offset%uint64(portCount))
+			a.offset += a.step
+
+			if _, taken := a.allocated[port]; taken {
+				continue
+			}
+
+			ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			if err != nil {
+				continue // port busy outside our tracking
+			}
+
+			listeners = append(listeners, ln)
+			ports = append(ports, port)
+			found = true
+			break
+		}
+		if !found {
+			cleanup()
+			return nil, fmt.Errorf("allocate port: exhausted %d candidates", portCount)
+		}
+	}
+
 	for _, port := range ports {
 		a.allocated[port] = instanceID
 	}
 	a.byInstance[instanceID] = append(a.byInstance[instanceID], ports...)
 
-	return ports, nil
+	return listeners, nil
 }
 
 // Release removes all port tracking for the given instance.
@@ -93,4 +110,14 @@ func (a *PortAllocator) Allocated() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return len(a.allocated)
+}
+
+// randomPrime returns a random prime in [2, max).
+func randomPrime(max uint64) uint64 {
+	for {
+		n := 2 + rand.Uint64N(max-2)
+		if big.NewInt(int64(n)).ProbablyPrime(20) {
+			return n
+		}
+	}
 }

--- a/internal/server/proxy/grpc.go
+++ b/internal/server/proxy/grpc.go
@@ -37,7 +37,7 @@ func (f *Forwarder) runGRPC(ctx context.Context) error {
 		getDecoder: func() *grpcDecoder { return f.Decoder },
 	}
 
-	ln, err := net.Listen("tcp", f.listenAddr())
+	ln, err := f.getListener()
 	if err != nil {
 		return fmt.Errorf("proxy %s→%s: listen: %w", f.Source, f.TargetSvc, err)
 	}

--- a/internal/server/proxy/http.go
+++ b/internal/server/proxy/http.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -37,7 +36,7 @@ func (f *Forwarder) runHTTP(ctx context.Context) error {
 		ingress: f.Ingress,
 	}
 
-	ln, err := net.Listen("tcp", f.listenAddr())
+	ln, err := f.getListener()
 	if err != nil {
 		return fmt.Errorf("proxy %s→%s: listen: %w", f.Source, f.TargetSvc, err)
 	}

--- a/internal/server/proxy/tcp.go
+++ b/internal/server/proxy/tcp.go
@@ -12,7 +12,7 @@ import (
 
 // runTCP starts a TCP relay that captures connection metadata.
 func (f *Forwarder) runTCP(ctx context.Context) error {
-	ln, err := net.Listen("tcp", f.listenAddr())
+	ln, err := f.getListener()
 	if err != nil {
 		return fmt.Errorf("proxy %s→%s: listen: %w", f.Source, f.TargetSvc, err)
 	}


### PR DESCRIPTION
## Summary

- Replace OS-assigned `:0` port allocation with a prime-stepping allocator that spreads ports across `[8192, 32768)` with a random offset and prime step, minimising collisions between concurrent rigd processes
- `Allocate` now returns open `[]net.Listener` — proxy forwarders use the listener directly (zero TOCTOU), service ports close it and use the port number
- Add `Listener` field and `getListener()` fallback to `proxy.Forwarder`; `http.go`, `tcp.go`, `grpc.go` use it instead of calling `net.Listen` directly

## Test plan

- [x] `make test` passes — all unit, integration, and example tests green
- [ ] Confirm CI passes with parallel integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)