### PR TITLE
Fix release workflow to push to main explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Parse version from tag
         id: version
@@ -68,4 +70,4 @@ jobs:
           git add client/version.go
           git diff --cached --quiet && exit 0
           git commit -m "Bump RigdVersion to ${{ steps.version.outputs.version }}"
-          git push origin HEAD:main
+          git push origin main


### PR DESCRIPTION
## Summary

- Checkout `main` explicitly in the version bump job — the release workflow triggers on a tag, so the default checkout is a detached HEAD on the tag ref
- Push to `main` directly instead of `HEAD:main` for clarity

## Test plan

- [ ] Tag a release and verify the version bump commit lands on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)