### PR TITLE
Add rig ls, test outcome recording, and glob-based log resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,26 @@ Sub-module integration tests (e.g. `connect/temporalx`, `connect/pgx`, `examples
 - `internal/testdata/` — test service fixtures (echo, tcpecho, userapi, fail)
 - `internal/integration/` — integration tests (require server + testdata)
 
+## Debugging test failures with `rig` CLI
+
+The `rig` CLI (`cmd/rig/`) inspects event logs written by `rigd`. Each test that calls `rig.Up` produces a `.jsonl` log file in `{RIG_DIR}/logs/`. Since `make test` runs many tests in parallel, always use the test name to find the right log — "most recent" is meaningless with parallel runs.
+
+```bash
+# See what failed
+rig ls --failed
+
+# Inspect a specific test's traffic (name matching is fuzzy — no path needed)
+rig traffic OrderFlow
+rig logs OrderFlow
+
+# Compose for scripting
+rig traffic $(rig ls --failed -q -n1)               # most recent failure
+rig ls --failed -q | xargs -I{} rig traffic {}      # all failures
+rig ls --failed -q -n1 Order                         # most recent OrderFlow failure
+```
+
+Key flags: `--failed`/`--passed` filter by outcome, `-q` outputs file paths for piping, `-n N` limits to N most recent results.
+
 ## Key conventions
 
 - Service types are registered in `internal/cmd/rigd/main.go` and `internal/integration/integration_test.go:startTestServer`

--- a/cmd/rig/logs.go
+++ b/cmd/rig/logs.go
@@ -75,6 +75,13 @@ func runLogs(args []string) error {
 		}
 	}
 
+	// Resolve glob pattern if the argument isn't a direct file path.
+	resolved, err := resolveLogFile(filename)
+	if err != nil {
+		return err
+	}
+	filename = resolved
+
 	f, err := os.Open(filename)
 	if err != nil {
 		return err

--- a/cmd/rig/ls.go
+++ b/cmd/rig/ls.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// lsHeader mirrors the log.header struct written by the server.
+type lsHeader struct {
+	Type        string   `json:"type"`
+	Environment string   `json:"environment"`
+	Outcome     string   `json:"outcome"`
+	Services    []string `json:"services"`
+	DurationMs  float64  `json:"duration_ms"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// lsEntry is a parsed log file summary ready for display.
+type lsEntry struct {
+	Path   string
+	Header lsHeader
+}
+
+// errNoResults is returned when ls finds no matching files.
+// main uses this to exit non-zero without printing an extra error.
+var errNoResults = fmt.Errorf("no results")
+
+func runLs(args []string) error {
+	// Extract positional glob pattern before flags.
+	pattern, flagArgs := extractFile(args)
+
+	fs := flag.NewFlagSet("ls", flag.ContinueOnError)
+	var (
+		failed bool
+		passed bool
+		quiet  bool
+		limit  int
+	)
+	fs.BoolVar(&failed, "failed", false, "only show failed/crashed logs")
+	fs.BoolVar(&passed, "passed", false, "only show passed logs")
+	fs.BoolVar(&quiet, "q", false, "output file paths only, one per line")
+	fs.IntVar(&limit, "n", 0, "limit to the N most recent results")
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if pattern == "" && fs.NArg() > 0 {
+		pattern = fs.Arg(0)
+	}
+
+	paths, err := scanLogDir(pattern)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintln(os.Stderr, "No log files found.")
+			return errNoResults
+		}
+		return fmt.Errorf("read log directory: %w", err)
+	}
+
+	var entries []lsEntry
+	for _, path := range paths {
+		hdr, err := readHeader(path)
+		if err != nil {
+			continue // skip files without a valid log.header
+		}
+
+		// Filter by outcome.
+		if failed && hdr.Outcome != "failed" && hdr.Outcome != "crashed" {
+			continue
+		}
+		if passed && hdr.Outcome != "passed" {
+			continue
+		}
+
+		entries = append(entries, lsEntry{Path: path, Header: hdr})
+	}
+
+	if len(entries) == 0 {
+		fmt.Fprintln(os.Stderr, "No matching log files.")
+		return errNoResults
+	}
+
+	// Sort by timestamp descending (newest first).
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Header.Timestamp.After(entries[j].Header.Timestamp)
+	})
+
+	if limit > 0 && limit < len(entries) {
+		entries = entries[:limit]
+	}
+
+	if quiet {
+		for _, e := range entries {
+			fmt.Println(e.Path)
+		}
+		return nil
+	}
+
+	renderLsTable(os.Stdout, entries)
+	return nil
+}
+
+// readHeader reads only the first line of a JSONL file and parses it as a
+// log.header event. Returns an error if the first line is not a log.header.
+func readHeader(path string) (lsHeader, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return lsHeader{}, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		return lsHeader{}, fmt.Errorf("empty file")
+	}
+
+	var hdr lsHeader
+	if err := json.Unmarshal(scanner.Bytes(), &hdr); err != nil {
+		return lsHeader{}, err
+	}
+	if hdr.Type != "log.header" {
+		return lsHeader{}, fmt.Errorf("not a log.header")
+	}
+	return hdr, nil
+}
+
+func renderLsTable(w io.Writer, entries []lsEntry) {
+	// Column headers and widths.
+	headers := []string{"TIME", "OUTCOME", "NAME", "DURATION", "SERVICES"}
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+
+	type row struct {
+		cols [5]string
+	}
+	rows := make([]row, len(entries))
+	for i, e := range entries {
+		timeStr := e.Header.Timestamp.Local().Format("2006-01-02 15:04:05")
+		outcome := e.Header.Outcome
+		if outcome == "" {
+			outcome = "unknown"
+		}
+		durStr := formatLsDuration(e.Header.DurationMs)
+		svcs := strings.Join(e.Header.Services, ", ")
+
+		rows[i] = row{cols: [5]string{
+			timeStr,
+			outcome,
+			e.Header.Environment,
+			durStr,
+			svcs,
+		}}
+		for j, c := range rows[i].cols {
+			if len(c) > widths[j] {
+				widths[j] = len(c)
+			}
+		}
+	}
+
+	// Print header.
+	for i, h := range headers {
+		if i > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprintf(w, "%-*s", widths[i], bold(h))
+	}
+	fmt.Fprintln(w)
+
+	// Print rows.
+	for _, r := range rows {
+		for i, c := range r.cols {
+			if i > 0 {
+				fmt.Fprint(w, "  ")
+			}
+			padded := fmt.Sprintf("%-*s", widths[i], c)
+			if i == 1 { // OUTCOME column
+				fmt.Fprint(w, colorOutcome(padded))
+			} else {
+				fmt.Fprint(w, padded)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+func colorOutcome(s string) string {
+	if !colorEnabled {
+		return s
+	}
+	trimmed := strings.TrimSpace(s)
+	switch trimmed {
+	case "passed":
+		return ansiGreen + s + ansiReset
+	case "failed", "crashed":
+		return ansiRed + s + ansiReset
+	}
+	return s
+}
+
+func formatLsDuration(ms float64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%.0fms", ms)
+	}
+	return fmt.Sprintf("%.2fs", ms/1000)
+}

--- a/cmd/rig/ls_test.go
+++ b/cmd/rig/ls_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadHeader(t *testing.T) {
+	hdr, err := readHeader("testdata/passed.jsonl")
+	if err != nil {
+		t.Fatalf("readHeader: %v", err)
+	}
+	if hdr.Type != "log.header" {
+		t.Errorf("type = %q, want log.header", hdr.Type)
+	}
+	if hdr.Environment != "TestBasic" {
+		t.Errorf("environment = %q, want TestBasic", hdr.Environment)
+	}
+	if hdr.Outcome != "passed" {
+		t.Errorf("outcome = %q, want passed", hdr.Outcome)
+	}
+	if len(hdr.Services) != 2 {
+		t.Errorf("services = %v, want [db api]", hdr.Services)
+	}
+	if hdr.DurationMs != 1200 {
+		t.Errorf("duration_ms = %v, want 1200", hdr.DurationMs)
+	}
+}
+
+func TestReadHeaderFailed(t *testing.T) {
+	hdr, err := readHeader("testdata/failed.jsonl")
+	if err != nil {
+		t.Fatalf("readHeader: %v", err)
+	}
+	if hdr.Outcome != "failed" {
+		t.Errorf("outcome = %q, want failed", hdr.Outcome)
+	}
+	if hdr.Environment != "TestOrderFlow" {
+		t.Errorf("environment = %q, want TestOrderFlow", hdr.Environment)
+	}
+}
+
+func TestReadHeaderNotAHeader(t *testing.T) {
+	// mixed_traffic.jsonl starts with a normal event, not a log.header.
+	_, err := readHeader("testdata/mixed_traffic.jsonl")
+	if err == nil {
+		t.Fatal("expected error for non-header first line")
+	}
+}
+
+// setupLsDir creates a temp rig dir with test log files and sets RIG_DIR.
+func setupLsDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "logs")
+	os.MkdirAll(logDir, 0o755)
+
+	copyFile(t, "testdata/passed.jsonl", filepath.Join(logDir, "TestBasic-19480a00000-aabbccdd.jsonl"))
+	copyFile(t, "testdata/failed.jsonl", filepath.Join(logDir, "TestOrderFlow-19480a00001-11223344.jsonl"))
+	copyFile(t, "testdata/crashed.jsonl", filepath.Join(logDir, "TestCrash-19480a00002-deadbeef.jsonl"))
+
+	t.Setenv("RIG_DIR", dir)
+}
+
+func TestRunLsWithDir(t *testing.T) {
+	setupLsDir(t)
+
+	// Test: list all.
+	output := captureStdout(t, func() {
+		if err := runLs(nil); err != nil {
+			t.Fatalf("runLs: %v", err)
+		}
+	})
+	if !strings.Contains(output, "TestBasic") {
+		t.Errorf("missing TestBasic in output:\n%s", output)
+	}
+	if !strings.Contains(output, "TestOrderFlow") {
+		t.Errorf("missing TestOrderFlow in output:\n%s", output)
+	}
+	if !strings.Contains(output, "TestCrash") {
+		t.Errorf("missing TestCrash in output:\n%s", output)
+	}
+
+	// Test: --failed filter.
+	output = captureStdout(t, func() {
+		if err := runLs([]string{"--failed"}); err != nil {
+			t.Fatalf("runLs --failed: %v", err)
+		}
+	})
+	if strings.Contains(output, "TestBasic") {
+		t.Errorf("--failed should not show passed test:\n%s", output)
+	}
+	if !strings.Contains(output, "TestOrderFlow") {
+		t.Errorf("--failed should show TestOrderFlow:\n%s", output)
+	}
+	if !strings.Contains(output, "TestCrash") {
+		t.Errorf("--failed should show TestCrash:\n%s", output)
+	}
+
+	// Test: --passed filter.
+	output = captureStdout(t, func() {
+		if err := runLs([]string{"--passed"}); err != nil {
+			t.Fatalf("runLs --passed: %v", err)
+		}
+	})
+	if !strings.Contains(output, "TestBasic") {
+		t.Errorf("--passed should show TestBasic:\n%s", output)
+	}
+	if strings.Contains(output, "TestOrderFlow") {
+		t.Errorf("--passed should not show failed test:\n%s", output)
+	}
+
+	// Test: glob filter.
+	output = captureStdout(t, func() {
+		if err := runLs([]string{"Order"}); err != nil {
+			t.Fatalf("runLs Order: %v", err)
+		}
+	})
+	if !strings.Contains(output, "TestOrderFlow") {
+		t.Errorf("glob should match TestOrderFlow:\n%s", output)
+	}
+	if strings.Contains(output, "TestBasic") {
+		t.Errorf("glob should not match TestBasic:\n%s", output)
+	}
+}
+
+func TestRunLsQuiet(t *testing.T) {
+	setupLsDir(t)
+
+	output := captureStdout(t, func() {
+		if err := runLs([]string{"-q"}); err != nil {
+			t.Fatalf("runLs -q: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 file paths, got %d: %s", len(lines), output)
+	}
+	for _, line := range lines {
+		if !strings.HasSuffix(line, ".jsonl") {
+			t.Errorf("expected .jsonl path, got: %s", line)
+		}
+	}
+}
+
+func TestRunLsQuietFailed(t *testing.T) {
+	setupLsDir(t)
+
+	output := captureStdout(t, func() {
+		if err := runLs([]string{"--failed", "-q"}); err != nil {
+			t.Fatalf("runLs --failed -q: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 file paths (failed + crashed), got %d: %s", len(lines), output)
+	}
+}
+
+func TestRunLsLimit(t *testing.T) {
+	setupLsDir(t)
+
+	output := captureStdout(t, func() {
+		if err := runLs([]string{"-q", "-n", "1"}); err != nil {
+			t.Fatalf("runLs -q -n 1: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 file path with -n 1, got %d: %s", len(lines), output)
+	}
+	// Should be the most recent (TestCrash has the latest timestamp in our fixtures).
+	if !strings.Contains(lines[0], "TestCrash") {
+		t.Errorf("-n 1 should return most recent file, got: %s", lines[0])
+	}
+}
+
+func TestRunLsNoResults(t *testing.T) {
+	setupLsDir(t)
+
+	// Search for a pattern that won't match anything.
+	err := runLs([]string{"nonexistent_pattern_xyz"})
+	if err != errNoResults {
+		t.Errorf("expected errNoResults, got: %v", err)
+	}
+}
+
+func TestRunLsEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RIG_DIR", dir)
+	// No logs/ dir at all.
+	err := runLs(nil)
+	if err != errNoResults {
+		t.Errorf("expected errNoResults for missing dir, got: %v", err)
+	}
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	// Disable colors since we're capturing to a pipe.
+	oldColor := colorEnabled
+	colorEnabled = false
+	defer func() {
+		colorEnabled = oldColor
+		os.Stdout = old
+	}()
+
+	fn()
+
+	w.Close()
+	data := make([]byte, 64*1024)
+	n, _ := r.Read(data)
+	return string(data[:n])
+}

--- a/cmd/rig/main.go
+++ b/cmd/rig/main.go
@@ -22,6 +22,13 @@ func main() {
 			fmt.Fprintf(os.Stderr, "rig logs: %v\n", err)
 			os.Exit(1)
 		}
+	case "ls":
+		if err := runLs(os.Args[2:]); err != nil {
+			if err != errNoResults {
+				fmt.Fprintf(os.Stderr, "rig ls: %v\n", err)
+			}
+			os.Exit(1)
+		}
 	case "help", "-h", "--help":
 		printUsage()
 	default:
@@ -35,8 +42,9 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, `Usage: rig <command> [flags]
 
 Commands:
-  traffic <file.jsonl>   Inspect traffic captured by rigd
-  logs    <file.jsonl>   View service logs
+  traffic <file>         Inspect traffic captured by rigd
+  logs    <file>         View service logs
+  ls      [pattern]      List recent log files
 
 Run 'rig <command> --help' for command-specific flags.
 `)

--- a/cmd/rig/resolve.go
+++ b/cmd/rig/resolve.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// defaultRigDir returns the base rig directory. Mirrors the server's
+// DefaultRigDir logic without importing the server package.
+func defaultRigDir() string {
+	if dir := os.Getenv("RIG_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "rig")
+	}
+	return filepath.Join(home, ".rig")
+}
+
+// scanLogDir returns all .jsonl file paths in {rigDir}/logs/ whose base
+// filename (without extension) matches the given glob pattern. Pass "" to
+// match all files. Results are sorted lexicographically (chronological
+// since IDs are time-prefixed).
+func scanLogDir(pattern string) ([]string, error) {
+	logDir := filepath.Join(defaultRigDir(), "logs")
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		return nil, err
+	}
+
+	glob := pattern
+	if glob != "" && !hasGlobMeta(glob) {
+		glob = "*" + glob + "*"
+	}
+
+	var paths []string
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
+		}
+		if glob != "" {
+			base := e.Name()[:len(e.Name())-len(".jsonl")]
+			ok, _ := filepath.Match(glob, base)
+			if !ok {
+				continue
+			}
+		}
+		paths = append(paths, filepath.Join(logDir, e.Name()))
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// resolveLogFile resolves a user-provided argument to a JSONL log file path.
+// If the argument is an existing file or contains a path separator, it is
+// returned as-is. Otherwise it is treated as a glob pattern and matched
+// against filenames (without .jsonl extension) in {rigDir}/logs/. If multiple
+// files match, the most recent (last lexicographically, since IDs are
+// time-prefixed) is returned.
+func resolveLogFile(arg string) (string, error) {
+	// Direct file path.
+	if _, err := os.Stat(arg); err == nil {
+		return arg, nil
+	}
+	// If it contains a path separator, it was meant as a path — don't glob.
+	if filepath.Base(arg) != arg {
+		return "", fmt.Errorf("file not found: %s", arg)
+	}
+
+	matches, err := scanLogDir(arg)
+	if err != nil {
+		return "", fmt.Errorf("cannot read log directory: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no log files matching %q in %s",
+			arg, filepath.Join(defaultRigDir(), "logs"))
+	}
+	return matches[len(matches)-1], nil
+}
+
+// hasGlobMeta reports whether s contains glob metacharacters.
+func hasGlobMeta(s string) bool {
+	for _, c := range s {
+		switch c {
+		case '*', '?', '[':
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/rig/testdata/crashed.jsonl
+++ b/cmd/rig/testdata/crashed.jsonl
@@ -1,0 +1,3 @@
+{"type":"log.header","environment":"TestCrash","outcome":"crashed","services":["worker"],"duration_ms":500,"timestamp":"2026-02-24T20:33:00Z"}
+{"seq":1,"type":"service.starting","environment":"TestCrash","service":"worker","timestamp":"2026-02-24T20:32:59Z"}
+{"seq":2,"type":"environment.failing","environment":"TestCrash","error":"service \"worker\": exit 1","timestamp":"2026-02-24T20:33:00Z"}

--- a/cmd/rig/testdata/failed.jsonl
+++ b/cmd/rig/testdata/failed.jsonl
@@ -1,0 +1,3 @@
+{"type":"log.header","environment":"TestOrderFlow","outcome":"failed","services":["db","temporal","api"],"duration_ms":3312,"timestamp":"2026-02-24T20:32:01Z"}
+{"seq":1,"type":"service.starting","environment":"TestOrderFlow","service":"db","timestamp":"2026-02-24T20:31:58Z"}
+{"seq":2,"type":"test.note","environment":"TestOrderFlow","error":"expected 200, got 500","timestamp":"2026-02-24T20:32:01Z"}

--- a/cmd/rig/testdata/passed.jsonl
+++ b/cmd/rig/testdata/passed.jsonl
@@ -1,0 +1,3 @@
+{"type":"log.header","environment":"TestBasic","outcome":"passed","services":["db","api"],"duration_ms":1200,"timestamp":"2026-02-24T20:30:00Z"}
+{"seq":1,"type":"service.starting","environment":"TestBasic","service":"db","timestamp":"2026-02-24T20:29:58Z"}
+{"seq":2,"type":"service.ready","environment":"TestBasic","service":"db","timestamp":"2026-02-24T20:30:00Z"}

--- a/cmd/rig/traffic.go
+++ b/cmd/rig/traffic.go
@@ -159,6 +159,13 @@ func runTraffic(args []string) error {
 		filter.protocol = "tcp"
 	}
 
+	// Resolve glob pattern if the argument isn't a direct file path.
+	resolved, err := resolveLogFile(filename)
+	if err != nil {
+		return err
+	}
+	filename = resolved
+
 	f, err := os.Open(filename)
 	if err != nil {
 		return err

--- a/internal/server/orchestrator.go
+++ b/internal/server/orchestrator.go
@@ -257,7 +257,7 @@ func sortedServiceNames(services map[string]spec.Service) []string {
 }
 
 func generateID() string {
-	b := make([]byte, 8)
+	b := make([]byte, 4)
 	rand.Read(b)
-	return fmt.Sprintf("%x", b)
+	return fmt.Sprintf("%x-%x", time.Now().UnixMilli(), b)
 }


### PR DESCRIPTION
## Summary

- **Test outcome recording**: Client signals `t.Failed()` to server on DELETE; server derives outcome (`passed`/`failed`/`crashed`) from events + client signal and writes it as a synthetic `log.header` first line in JSONL for O(1) scanning
- **`rig ls` command**: List recent logs with `--failed`/`--passed` filtering, `-n` limit, `-q` quiet mode for scripting, and fuzzy name matching
- **Glob-based file resolution**: `rig traffic OrderFlow` and `rig logs OrderFlow` resolve bare test names to log files without full paths
- **Time-prefixed IDs**: Environment IDs now use hex timestamp prefix for chronological sorting
- **Improved failure output**: Test cleanup logs copy-pasteable `rig traffic`/`rig logs` commands with `RIG_DIR` prefix when set

Closes #23, closes #37.

## Changes

| File | Change |
|------|--------|
| `internal/server/orchestrator.go` | `generateID()` → time-prefixed hex format |
| `internal/server/server.go` | `reason` field on DELETE, `deriveOutcome()`, `log.header` first line, enriched `.log` header, return both paths |
| `client/rig.go` | `destroyResult` struct, pass `t.Failed()`, improved cleanup logging with bare names + `RIG_DIR` |
| `cmd/rig/resolve.go` | Shared `scanLogDir()`, `resolveLogFile()`, `defaultRigDir()` |
| `cmd/rig/ls.go` | `rig ls` command with `--failed`/`--passed`/`-q`/`-n` flags |
| `cmd/rig/ls_test.go` | Tests for ls with testdata fixtures |
| `cmd/rig/main.go` | Add `ls` subcommand |
| `cmd/rig/traffic.go` | Integrate `resolveLogFile()` for glob resolution |
| `cmd/rig/logs.go` | Integrate `resolveLogFile()` for glob resolution |
| `CLAUDE.md` | Debugging section with name-directed workflow |
| `agents-guide.md` | Expanded debugging section with composable examples |

## Test plan

- [x] `make test` passes (sortable IDs are backwards-compatible, `log.header` ignored by existing parsers)
- [x] `cd cmd/rig && go test ./...` — ls tests pass
- [x] Manual: run an example test, verify first line of JSONL is `log.header` with correct fields
- [x] Manual: `rig ls` shows recent logs with outcome; `rig ls --failed` filters correctly
- [x] Manual: `rig traffic OrderFlow` resolves by name without full path

🤖 Generated with [Claude Code](https://claude.com/claude-code)