### PR TITLE
Add background refresh for mutable Docker image cache

### DIFF
--- a/internal/server/artifact/cache.go
+++ b/internal/server/artifact/cache.go
@@ -23,6 +23,9 @@ func NewCache(dir string) *Cache {
 	return &Cache{dir: dir}
 }
 
+// Dir returns the cache root directory.
+func (c *Cache) Dir() string { return c.dir }
+
 // OutputDir returns the directory where a resolver should place its output for
 // cacheKey. The directory is created if it does not exist.
 func (c *Cache) OutputDir(cacheKey string) string {
@@ -35,10 +38,10 @@ func (c *Cache) OutputDir(cacheKey string) string {
 // resolution work across concurrent rigd instances. Returns an unlock function
 // that must be called when the critical section is done.
 func (c *Cache) Lock(cacheKey string) (unlock func(), err error) {
-	if err := os.MkdirAll(c.dir, 0o755); err != nil {
+	lockPath := filepath.Join(c.dir, cacheKey+".lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
 		return nil, fmt.Errorf("create cache dir: %w", err)
 	}
-	lockPath := filepath.Join(c.dir, cacheKey+".lock")
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("open lock file: %w", err)

--- a/internal/server/artifact/docker.go
+++ b/internal/server/artifact/docker.go
@@ -79,9 +79,13 @@ func (d DockerPull) Resolve(ctx context.Context, outputDir string) (Output, erro
 
 	imageID := inspect.ID
 
-	// Write breadcrumb so Cached finds it next time.
+	// Write breadcrumbs so Cached finds the image next time, and the background
+	// refresher knows the original tag for re-pulling.
 	if err := os.WriteFile(filepath.Join(outputDir, ".image-id"), []byte(imageID), 0o644); err != nil {
 		return Output{}, fmt.Errorf("write breadcrumb: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, ".image-ref"), []byte(d.Image), 0o644); err != nil {
+		return Output{}, fmt.Errorf("write image-ref breadcrumb: %w", err)
 	}
 
 	return Output{

--- a/internal/server/artifact/refresh.go
+++ b/internal/server/artifact/refresh.go
@@ -1,0 +1,161 @@
+package artifact
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DefaultStaleAfter is the default staleness window for background refresh.
+// Docker image tags like postgres:16 or redis:8 change infrequently — a daily
+// check is more than sufficient.
+const DefaultStaleAfter = 24 * time.Hour
+
+// Refresher performs a single pass over cached Docker images, pulling mutable
+// tags that haven't been checked recently and updating the cached image ID if
+// the upstream changed. It uses the same Cache lock and DockerPull.Resolve
+// path as normal artifact resolution, so there's one code path for writing
+// cache breadcrumbs and no concurrent-write concerns.
+type Refresher struct {
+	cache      *Cache
+	staleAfter time.Duration
+	resolve    resolveFunc // injectable for testing
+}
+
+// resolveFunc pulls a Docker image and writes breadcrumbs to outputDir.
+// The default implementation uses DockerPull.Resolve; tests inject a fake.
+type resolveFunc func(ctx context.Context, imageRef string, outputDir string) error
+
+// NewRefresher creates a Refresher that scans cache for stale Docker entries.
+func NewRefresher(cache *Cache, staleAfter time.Duration) *Refresher {
+	return &Refresher{
+		cache:      cache,
+		staleAfter: staleAfter,
+		resolve:    defaultResolve,
+	}
+}
+
+// defaultResolve pulls a Docker image via the same path as normal artifact
+// resolution — DockerPull.Resolve writes .image-id and .image-ref breadcrumbs.
+func defaultResolve(ctx context.Context, imageRef string, outputDir string) error {
+	_, err := DockerPull{Image: imageRef}.Resolve(ctx, outputDir)
+	return err
+}
+
+// RefreshOnce performs a single refresh pass over all cached Docker entries.
+// It checks ctx between entries so callers can cancel mid-scan.
+func (r *Refresher) RefreshOnce(ctx context.Context) {
+	entries := scanDockerEntries(r.cache.Dir())
+	for _, e := range entries {
+		if ctx.Err() != nil {
+			return
+		}
+		if !isMutableRef(e.imageRef) {
+			continue
+		}
+		if !shouldRefresh(e.dir, r.staleAfter) {
+			continue
+		}
+		r.refreshEntry(ctx, e)
+	}
+}
+
+// refreshEntry acquires the cache lock for this entry, then re-resolves the
+// image through the normal DockerPull.Resolve path.
+func (r *Refresher) refreshEntry(ctx context.Context, e dockerEntry) {
+	unlock, err := r.cache.Lock(e.cacheKey)
+	if err != nil {
+		return
+	}
+	defer unlock()
+
+	if err := r.resolve(ctx, e.imageRef, e.dir); err != nil {
+		// Pull failed — don't touch .last-checked so the entry gets retried
+		// on the next idle period rather than being suppressed for the full
+		// stale window.
+		return
+	}
+	touchLastChecked(e.dir)
+}
+
+// dockerEntry represents a cached Docker image entry on disk.
+type dockerEntry struct {
+	dir      string
+	imageRef string
+	cacheKey string
+}
+
+// scanDockerEntries walks cacheDir/docker/ and returns entries that have both
+// .image-ref and .image-id files. Entries without .image-ref are skipped
+// (pre-existing cache entries that haven't been re-resolved yet). Entries
+// without .image-id are skipped (resolution never completed).
+func scanDockerEntries(cacheDir string) []dockerEntry {
+	dockerDir := filepath.Join(cacheDir, "docker")
+	dirEntries, err := os.ReadDir(dockerDir)
+	if err != nil {
+		return nil
+	}
+
+	var entries []dockerEntry
+	for _, de := range dirEntries {
+		if !de.IsDir() {
+			continue
+		}
+		dir := filepath.Join(dockerDir, de.Name())
+
+		refData, err := os.ReadFile(filepath.Join(dir, ".image-ref"))
+		if err != nil {
+			continue // no .image-ref — skip
+		}
+		imageRef := strings.TrimSpace(string(refData))
+		if imageRef == "" {
+			continue
+		}
+
+		// Verify .image-id exists — if resolution never completed, skip.
+		if _, err := os.Stat(filepath.Join(dir, ".image-id")); err != nil {
+			continue
+		}
+
+		cacheKey, err := DockerPull{Image: imageRef}.CacheKey()
+		if err != nil {
+			continue
+		}
+
+		entries = append(entries, dockerEntry{
+			dir:      dir,
+			imageRef: imageRef,
+			cacheKey: cacheKey,
+		})
+	}
+	return entries
+}
+
+// isMutableRef returns true if the image reference could point to a different
+// image over time. Digest references (containing @sha256:) are immutable.
+func isMutableRef(ref string) bool {
+	return !strings.Contains(ref, "@sha256:")
+}
+
+// shouldRefresh returns true if the entry's .last-checked file is missing or
+// older than staleAfter.
+func shouldRefresh(dir string, staleAfter time.Duration) bool {
+	info, err := os.Stat(filepath.Join(dir, ".last-checked"))
+	if err != nil {
+		return true // no .last-checked — never checked
+	}
+	return time.Since(info.ModTime()) > staleAfter
+}
+
+// touchLastChecked creates or updates the mtime of .last-checked in dir.
+func touchLastChecked(dir string) {
+	path := filepath.Join(dir, ".last-checked")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	f.Close()
+	os.Chtimes(path, time.Now(), time.Now())
+}

--- a/internal/server/artifact/refresh_test.go
+++ b/internal/server/artifact/refresh_test.go
@@ -1,0 +1,280 @@
+package artifact
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIsMutableRef(t *testing.T) {
+	tests := []struct {
+		ref     string
+		mutable bool
+	}{
+		{"postgres:16", true},
+		{"redis:7-alpine", true},
+		{"myimage:latest", true},
+		{"myimage", true},
+		{"ghcr.io/org/image:v1.2.3", true},
+		{"myimage@sha256:abc123def456", false},
+		{"ghcr.io/org/image@sha256:abc123", false},
+	}
+	for _, tt := range tests {
+		if got := isMutableRef(tt.ref); got != tt.mutable {
+			t.Errorf("isMutableRef(%q) = %v, want %v", tt.ref, got, tt.mutable)
+		}
+	}
+}
+
+func TestShouldRefresh(t *testing.T) {
+	t.Run("no last-checked file", func(t *testing.T) {
+		dir := t.TempDir()
+		if !shouldRefresh(dir, time.Hour) {
+			t.Error("expected shouldRefresh=true when .last-checked is missing")
+		}
+	})
+
+	t.Run("recent last-checked", func(t *testing.T) {
+		dir := t.TempDir()
+		touchLastChecked(dir)
+		if shouldRefresh(dir, time.Hour) {
+			t.Error("expected shouldRefresh=false when .last-checked is recent")
+		}
+	})
+
+	t.Run("old last-checked", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".last-checked")
+		os.WriteFile(path, nil, 0o644)
+		old := time.Now().Add(-2 * time.Hour)
+		os.Chtimes(path, old, old)
+		if !shouldRefresh(dir, time.Hour) {
+			t.Error("expected shouldRefresh=true when .last-checked is old")
+		}
+	})
+}
+
+func TestScanDockerEntries(t *testing.T) {
+	cacheDir := t.TempDir()
+	dockerDir := filepath.Join(cacheDir, "docker")
+
+	// Entry with both files — should be included.
+	good := filepath.Join(dockerDir, "entry1")
+	os.MkdirAll(good, 0o755)
+	os.WriteFile(filepath.Join(good, ".image-ref"), []byte("postgres:16"), 0o644)
+	os.WriteFile(filepath.Join(good, ".image-id"), []byte("sha256:abc123"), 0o644)
+
+	// Entry missing .image-ref — should be skipped.
+	noRef := filepath.Join(dockerDir, "entry2")
+	os.MkdirAll(noRef, 0o755)
+	os.WriteFile(filepath.Join(noRef, ".image-id"), []byte("sha256:def456"), 0o644)
+
+	// Entry missing .image-id — should be skipped.
+	noID := filepath.Join(dockerDir, "entry3")
+	os.MkdirAll(noID, 0o755)
+	os.WriteFile(filepath.Join(noID, ".image-ref"), []byte("redis:7"), 0o644)
+
+	// Entry with empty .image-ref — should be skipped.
+	emptyRef := filepath.Join(dockerDir, "entry4")
+	os.MkdirAll(emptyRef, 0o755)
+	os.WriteFile(filepath.Join(emptyRef, ".image-ref"), []byte(""), 0o644)
+	os.WriteFile(filepath.Join(emptyRef, ".image-id"), []byte("sha256:ghi789"), 0o644)
+
+	entries := scanDockerEntries(cacheDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].imageRef != "postgres:16" {
+		t.Errorf("imageRef = %q, want %q", entries[0].imageRef, "postgres:16")
+	}
+}
+
+func TestScanDockerEntries_NoCacheDir(t *testing.T) {
+	entries := scanDockerEntries("/nonexistent/path")
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries for nonexistent dir, got %d", len(entries))
+	}
+}
+
+// newTestRefresher creates a Refresher backed by a temp-dir cache with a fake
+// resolve function. The cache dir is returned for setting up test fixtures.
+func newTestRefresher(t *testing.T, staleAfter time.Duration, resolve resolveFunc) (*Refresher, string) {
+	t.Helper()
+	cacheDir := t.TempDir()
+	r := NewRefresher(NewCache(cacheDir), staleAfter)
+	r.resolve = resolve
+	return r, cacheDir
+}
+
+// writeDockerEntry creates a cached Docker image entry in cacheDir for testing.
+func writeDockerEntry(t *testing.T, cacheDir, name, imageRef, imageID string) string {
+	t.Helper()
+	dir := filepath.Join(cacheDir, "docker", name)
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, ".image-ref"), []byte(imageRef), 0o644)
+	os.WriteFile(filepath.Join(dir, ".image-id"), []byte(imageID), 0o644)
+	return dir
+}
+
+func TestRefreshOnce_UpdatesStaleEntry(t *testing.T) {
+	r, cacheDir := newTestRefresher(t, 0, func(ctx context.Context, imageRef, outputDir string) error {
+		if imageRef != "postgres:16" {
+			t.Errorf("resolve imageRef = %q, want %q", imageRef, "postgres:16")
+		}
+		return os.WriteFile(filepath.Join(outputDir, ".image-id"), []byte("sha256:new"), 0o644)
+	})
+	dir := writeDockerEntry(t, cacheDir, "entry1", "postgres:16", "sha256:old")
+
+	r.RefreshOnce(context.Background())
+
+	data, err := os.ReadFile(filepath.Join(dir, ".image-id"))
+	if err != nil {
+		t.Fatalf("read .image-id: %v", err)
+	}
+	if string(data) != "sha256:new" {
+		t.Errorf(".image-id = %q, want %q", string(data), "sha256:new")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".last-checked")); err != nil {
+		t.Errorf("expected .last-checked to exist: %v", err)
+	}
+}
+
+func TestRefreshOnce_SkipsRecentlyChecked(t *testing.T) {
+	pullCalled := false
+	r, cacheDir := newTestRefresher(t, time.Hour, func(ctx context.Context, imageRef, outputDir string) error {
+		pullCalled = true
+		return nil
+	})
+	dir := writeDockerEntry(t, cacheDir, "entry1", "postgres:16", "sha256:old")
+	touchLastChecked(dir)
+
+	r.RefreshOnce(context.Background())
+
+	if pullCalled {
+		t.Error("expected no resolve for recently-checked entry")
+	}
+}
+
+func TestRefreshOnce_SkipsImmutableDigest(t *testing.T) {
+	pullCalled := false
+	r, cacheDir := newTestRefresher(t, 0, func(ctx context.Context, imageRef, outputDir string) error {
+		pullCalled = true
+		return nil
+	})
+	writeDockerEntry(t, cacheDir, "entry1", "myimage@sha256:abc123", "sha256:abc123")
+
+	r.RefreshOnce(context.Background())
+
+	if pullCalled {
+		t.Error("expected no resolve for immutable digest")
+	}
+}
+
+func TestRefreshOnce_TouchesLastCheckedOnSuccess(t *testing.T) {
+	r, cacheDir := newTestRefresher(t, 0, func(ctx context.Context, imageRef, outputDir string) error {
+		// Resolve succeeds without changing the image — .last-checked should still be touched.
+		return os.WriteFile(filepath.Join(outputDir, ".image-id"), []byte("sha256:same"), 0o644)
+	})
+	dir := writeDockerEntry(t, cacheDir, "entry1", "postgres:16", "sha256:same")
+
+	r.RefreshOnce(context.Background())
+
+	if _, err := os.Stat(filepath.Join(dir, ".last-checked")); err != nil {
+		t.Errorf("expected .last-checked to exist: %v", err)
+	}
+}
+
+func TestRefreshOnce_ContextCancelStopsMidScan(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	resolveCount := 0
+
+	r, cacheDir := newTestRefresher(t, 0, func(ctx context.Context, imageRef, outputDir string) error {
+		resolveCount++
+		cancel() // Cancel after first resolve.
+		return os.WriteFile(filepath.Join(outputDir, ".image-id"), []byte("sha256:new"), 0o644)
+	})
+	writeDockerEntry(t, cacheDir, "entry1", "image:1", "sha256:old")
+	writeDockerEntry(t, cacheDir, "entry2", "image:2", "sha256:old")
+
+	r.RefreshOnce(ctx)
+
+	if resolveCount != 1 {
+		t.Errorf("expected 1 resolve before cancellation, got %d", resolveCount)
+	}
+}
+
+func TestRefreshOnce_ResolveErrorSkipsLastChecked(t *testing.T) {
+	r, cacheDir := newTestRefresher(t, 0, func(ctx context.Context, imageRef, outputDir string) error {
+		return errors.New("network error")
+	})
+	dir := writeDockerEntry(t, cacheDir, "entry1", "postgres:16", "sha256:old")
+
+	r.RefreshOnce(context.Background())
+
+	// .last-checked should NOT exist — failed resolves don't suppress retries.
+	if _, err := os.Stat(filepath.Join(dir, ".last-checked")); !os.IsNotExist(err) {
+		t.Error("expected .last-checked to not exist after resolve failure")
+	}
+	// .image-id should be unchanged.
+	data, _ := os.ReadFile(filepath.Join(dir, ".image-id"))
+	if string(data) != "sha256:old" {
+		t.Errorf(".image-id = %q, want %q", string(data), "sha256:old")
+	}
+}
+
+func TestRefreshOnce_NoCacheDir(t *testing.T) {
+	r := NewRefresher(NewCache("/nonexistent/path"), 0)
+	// Should not panic.
+	r.RefreshOnce(context.Background())
+}
+
+func TestRefreshOnce_AcquiresCacheLock(t *testing.T) {
+	r, cacheDir := newTestRefresher(t, 0, func(ctx context.Context, imageRef, outputDir string) error {
+		return os.WriteFile(filepath.Join(outputDir, ".image-id"), []byte("sha256:new"), 0o644)
+	})
+	dir := writeDockerEntry(t, cacheDir, "entry1", "postgres:16", "sha256:old")
+
+	// Pre-acquire the same cache lock that refreshEntry will use.
+	cacheKey, err := DockerPull{Image: "postgres:16"}.CacheKey()
+	if err != nil {
+		t.Fatalf("cache key: %v", err)
+	}
+	unlock, err := r.cache.Lock(cacheKey)
+	if err != nil {
+		t.Fatalf("acquire lock: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		r.RefreshOnce(context.Background())
+		close(done)
+	}()
+
+	// Give RefreshOnce time to reach the lock.
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-done:
+		t.Fatal("RefreshOnce completed while lock was held — expected it to block")
+	default:
+		// Good — it's blocked on the lock.
+	}
+
+	unlock()
+
+	select {
+	case <-done:
+		// Good — completed after unlock.
+	case <-time.After(2 * time.Second):
+		t.Fatal("RefreshOnce did not complete after lock release")
+	}
+
+	// Verify the resolve ran.
+	data, _ := os.ReadFile(filepath.Join(dir, ".image-id"))
+	if string(data) != "sha256:new" {
+		t.Errorf(".image-id = %q, want %q", string(data), "sha256:new")
+	}
+}


### PR DESCRIPTION
## Summary

- During server idle periods (no active environments), a background goroutine scans cached Docker entries, re-pulls mutable tags not checked within 24 hours, and updates the cached image ID if upstream changed
- Shares a single `Cache` instance between the resolver framework and refresher, using `Cache.Lock()` to prevent concurrent writes
- Routes refreshes through `DockerPull.Resolve` so there's one code path for writing cache breadcrumbs
- Writes `.image-ref` breadcrumb during `Resolve` so the refresher can recover the original tag
- Fixes `Cache.Lock()` to `MkdirAll` the lock file's parent directory (cache keys contain `/`)

Closes #39

## Test plan

- [x] `make test` — all existing tests pass (additive change)
- [x] Unit tests for `isMutableRef`, `shouldRefresh`, `scanDockerEntries`
- [x] `RefreshOnce` tests: updates stale entries, skips recent/immutable, handles errors, respects context cancellation, acquires cache lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)