### PR TITLE
Put temp dirs under rig directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-all test fmt clean clean-bin clean-logs clean-cache
+.PHONY: build build-all test fmt clean clean-bin clean-logs clean-cache clean-tmp
 
 PLATFORMS := linux-amd64 linux-arm64 darwin-amd64 darwin-arm64
 
@@ -24,8 +24,8 @@ test: build
 fmt:
 	gofmt -w .
 
-# Remove build artifacts, logs, and cache
-clean: clean-bin clean-logs clean-cache
+# Remove build artifacts, logs, cache, and temp dirs
+clean: clean-bin clean-logs clean-cache clean-tmp
 
 # Remove build artifacts
 clean-bin:
@@ -38,3 +38,7 @@ clean-logs:
 # Remove artifact cache (.rig/cache/)
 clean-cache:
 	rm -rf .rig/cache/
+
+# Remove preserved temp dirs (.rig/tmp/)
+clean-tmp:
+	rm -rf .rig/tmp/

--- a/internal/cmd/rigd/main.go
+++ b/internal/cmd/rigd/main.go
@@ -38,7 +38,7 @@ func main() {
 	s := server.NewServer(
 		server.NewPortAllocator(),
 		reg,
-		"", // tempBase — use OS default
+		filepath.Join(*rigDir, "tmp"),
 		*idle,
 		*rigDir,
 	)

--- a/scripts/release-rigd.sh
+++ b/scripts/release-rigd.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the latest rigd release tag
+latest=$(git tag --list 'rigd/v*' --sort=-v:refname | head -1)
+if [ -z "$latest" ]; then
+	echo "No existing rigd/v* tags found." >&2
+	exit 1
+fi
+
+# Extract minor version and bump it
+minor=$(echo "$latest" | sed 's|rigd/v0\.\([0-9]*\)\.0|\1|')
+next=$((minor + 1))
+tag="rigd/v0.${next}.0"
+
+echo "Previous release: $latest"
+echo "New release:      $tag"
+echo ""
+
+read -rp "Create and push tag? [y/N] " confirm
+if [[ "$confirm" != [yY] ]]; then
+	echo "Aborted."
+	exit 0
+fi
+
+git tag -a "$tag" -m "Release $tag"
+git push origin "$tag"
+
+echo ""
+echo "Tagged and pushed $tag"


### PR DESCRIPTION
## Summary
- Temp dirs now live under `{rigDir}/tmp/` instead of `os.TempDir()/rig`, so all rig state (logs, cache, temp) is colocated under a single directory.
- Makes `RIG_PRESERVE_ON_FAILURE` artifacts easy to find — they're next to the logs, not buried in `/tmp/`.
- On CI, a single `tar -czf artifacts.tar.gz .rig/` collects everything needed to debug a failure.
- Adds `make clean-tmp` target and `scripts/release-rigd.sh` for tagging minor releases.

## Test plan
- [x] `make test` passes — all modules green

🤖 Generated with [Claude Code](https://claude.com/claude-code)