### PR TITLE
Mount temp dirs into containers and expand args at point of use

### DIFF
--- a/internal/server/lifecycle.go
+++ b/internal/server/lifecycle.go
@@ -303,7 +303,6 @@ func runWithLifecycle(sc *serviceContext) run.Runner {
 		}
 
 		env := BuildServiceEnv(sc.name, sc.ingresses, sc.egresses, sc.tempDir, sc.envDir)
-		args := ExpandTemplates(sc.spec.Args, env)
 
 		runner := sc.svcType.Runner(service.StartParams{
 			ServiceName: sc.name,
@@ -312,7 +311,7 @@ func runWithLifecycle(sc *serviceContext) run.Runner {
 			Egresses:    sc.egresses,
 			Artifacts:   sc.artifacts,
 			Env:         env,
-			Args:        args,
+			Args:        sc.spec.Args,
 			TempDir:     sc.tempDir,
 			EnvDir:      sc.envDir,
 			InstanceID:  sc.instanceID,

--- a/internal/server/service/gobuild.go
+++ b/internal/server/service/gobuild.go
@@ -69,7 +69,7 @@ func (Go) Runner(params StartParams) run.Runner {
 	return run.Process{
 		Name:   params.ServiceName,
 		Path:   out.Path,
-		Args:   params.Args,
+		Args:   expandAll(params.Args, params.Env),
 		Env:    params.Env,
 		Stdout: params.Stdout,
 		Stderr: params.Stderr,

--- a/internal/server/service/process.go
+++ b/internal/server/service/process.go
@@ -42,7 +42,7 @@ func (Process) Runner(params StartParams) run.Runner {
 		Name:   params.ServiceName,
 		Path:   cfg.Command,
 		Dir:    cfg.Dir,
-		Args:   params.Args,
+		Args:   expandAll(params.Args, params.Env),
 		Env:    params.Env,
 		Stdout: params.Stdout,
 		Stderr: params.Stderr,

--- a/internal/server/service/type.go
+++ b/internal/server/service/type.go
@@ -27,7 +27,7 @@ type StartParams struct {
 	Egresses    map[string]spec.Endpoint   // resolved egresses (from wiring)
 	Artifacts   map[string]artifact.Output // keyed by Artifact.Key (from artifact phase)
 	Env         map[string]string          // pre-built environment variables
-	Args        []string                   // pre-expanded command arguments
+	Args        []string                   // raw command arg templates (expand against Env or adjusted env)
 	TempDir     string
 	EnvDir      string
 	InstanceID  string // environment instance ID (used for container naming)


### PR DESCRIPTION
## Summary

- **Bind-mount temp dirs** into containers at fixed paths (`/rig/temp` for the service temp dir, `/rig/env` for the environment dir). Previously containers received `RIG_TEMP_DIR` and `RIG_ENV_DIR` env vars pointing to host paths that didn't exist inside the container.
- **Adjust env vars and `RIG_WIRING` JSON** to reference the container mount paths instead of host paths.
- **Move arg template expansion into each Runner** instead of pre-expanding in lifecycle.go with host paths. Each service type now expands `${VAR}` references against its own env, so `${RIG_TEMP_DIR}` in args resolves correctly for both containers and host processes. Removes the `replaceHost` helper — `expandAll` against the adjusted env handles host address substitution naturally.

## Test plan

- [x] Unit tests for `adjustTempDirsInWiring` (new)
- [x] All existing server/service tests pass
- [x] Full `internal/` test suite passes including integration tests
- [ ] Manual: run a container service that reads `$RIG_TEMP_DIR` and verify it resolves to `/rig/temp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)