### PR TITLE
Replace AddressAttrs with template expansion

### DIFF
--- a/client/stream.go
+++ b/client/stream.go
@@ -63,11 +63,10 @@ type wireCallbackRequest struct {
 }
 
 type wireWiringContext struct {
-	Ingresses  map[string]wireEndpoint `json:"ingresses,omitempty"`
-	Egresses   map[string]wireEndpoint `json:"egresses,omitempty"`
-	TempDir    string                  `json:"temp_dir,omitempty"`
-	EnvDir     string                  `json:"env_dir,omitempty"`
-	Attributes map[string]string       `json:"attributes,omitempty"`
+	Ingresses map[string]wireEndpoint `json:"ingresses,omitempty"`
+	Egresses  map[string]wireEndpoint `json:"egresses,omitempty"`
+	TempDir   string                  `json:"temp_dir,omitempty"`
+	EnvDir    string                  `json:"env_dir,omitempty"`
 }
 
 type wireEndpoint struct {
@@ -338,11 +337,10 @@ func convertWiring(w *wireWiringContext) Wiring {
 		return Wiring{}
 	}
 	return Wiring{
-		Ingresses:  convertEndpoints(w.Ingresses),
-		Egresses:   convertEndpoints(w.Egresses),
-		Attributes: w.Attributes,
-		TempDir:    w.TempDir,
-		EnvDir:     w.EnvDir,
+		Ingresses: convertEndpoints(w.Ingresses),
+		Egresses:  convertEndpoints(w.Egresses),
+		TempDir:   w.TempDir,
+		EnvDir:    w.EnvDir,
 	}
 }
 

--- a/connect/wiring.go
+++ b/connect/wiring.go
@@ -12,11 +12,10 @@ import (
 // Wiring provides resolved endpoint information to services and hook
 // functions. Use ParseWiring to read from the environment.
 type Wiring struct {
-	Ingresses  map[string]Endpoint `json:"ingresses,omitempty"`
-	Egresses   map[string]Endpoint `json:"egresses,omitempty"`
-	Attributes map[string]string   `json:"attributes,omitempty"`
-	TempDir    string              `json:"temp_dir,omitempty"`
-	EnvDir     string              `json:"env_dir,omitempty"`
+	Ingresses map[string]Endpoint `json:"ingresses,omitempty"`
+	Egresses  map[string]Endpoint `json:"egresses,omitempty"`
+	TempDir   string              `json:"temp_dir,omitempty"`
+	EnvDir    string              `json:"env_dir,omitempty"`
 }
 
 // Ingress returns the named ingress endpoint. If no name is provided,

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -265,17 +265,13 @@ Resolved at runtime by the server. Never appears in the spec — only in events 
 {
   "host": "127.0.0.1",
   "port": 54321,
-  "protocol": "http",
+  "protocol": "tcp",
   "attributes": {
     "PGHOST": "127.0.0.1",
     "PGPORT": "54321",
     "PGUSER": "postgres",
     "PGPASSWORD": "postgres",
     "PGDATABASE": "test_abc123"
-  },
-  "address_attrs": {
-    "PGHOST": "host",
-    "PGPORT": "port"
   }
 }
 ```
@@ -285,15 +281,26 @@ Resolved at runtime by the server. Never appears in the spec — only in events 
 | `host` | string | Hostname or IP |
 | `port` | integer | Port number |
 | `protocol` | string | `"tcp"`, `"http"`, `"grpc"`, `"kafka"` |
-| `attributes` | object | Key-value attributes (typed as `any` — strings, numbers, booleans) |
-| `address_attrs` | object | Declares which attributes derive from the address (`"host"`, `"port"`, `"hostport"`). Used by the proxy layer to rewrite attributes when the address changes. |
+| `attributes` | object | Key-value attributes (typed as `any` — strings, numbers, booleans). Attributes sent to clients are fully resolved; internally attributes may contain `${VAR}` template references. |
+
+### Attribute template variables
+
+Service type implementations store attribute values as templates referencing built-in variables. These are resolved before being sent to clients (in `environment.up` events and `GET /environments/{id}` responses).
+
+| Variable | Source | Example value |
+|----------|--------|---------------|
+| `HOST` | `ep.Host` | `127.0.0.1` |
+| `PORT` | `ep.Port` | `5432` |
+| `HOSTPORT` | `ep.Host:ep.Port` | `127.0.0.1:5432` |
+
+Only these three built-in variables are available. Templates use `${VAR}` syntax and are resolved in a single pass. Referencing an unknown variable is an error.
 
 Well-known attributes published by built-in service types:
 
-| Service | Attributes |
-|---------|-----------|
-| Postgres | `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` |
-| Temporal | `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE` |
+| Service | Attributes | Template forms |
+|---------|-----------|---------------|
+| Postgres | `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` | `PGHOST="${HOST}"`, `PGPORT="${PORT}"` |
+| Temporal | `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE` | `TEMPORAL_ADDRESS="${HOSTPORT}"` |
 
 ---
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -144,7 +144,9 @@ Runs a PostgreSQL container with automatic wiring.
 
 - **No user-defined ingress**: fixed TCP on port 5432
 - **Default image**: `postgres:16-alpine`
-- **Published attributes**: `PGHOST`, `PGPORT`, `PGDATABASE` (= service name), `PGUSER`, `PGPASSWORD`
+- **Published attributes**: `PGHOST` (`${HOST}`), `PGPORT` (`${PORT}`), `PGDATABASE` (= service name), `PGUSER`, `PGPASSWORD`
+
+Address-derived attributes use template variables (`${HOST}`, `${PORT}`) and are resolved automatically when the endpoint is consumed. This means they stay correct through container port remapping and proxy address rewriting.
 
 ```go
 rig.Postgres().
@@ -158,7 +160,9 @@ Downloads and runs a Temporal dev server.
 - **Default ingresses**: `"default"` (gRPC) + `"ui"` (HTTP)
 - **Default CLI version**: `1.5.1`
 - **Default namespace**: `"default"`
-- **Published attributes**: `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE`
+- **Published attributes**: `TEMPORAL_ADDRESS` (`${HOSTPORT}`), `TEMPORAL_NAMESPACE`
+
+`TEMPORAL_ADDRESS` uses the `${HOSTPORT}` template variable, which resolves to `host:port` — staying correct through proxy address rewriting.
 
 ```go
 rig.Temporal().

--- a/internal/server/eventlog.go
+++ b/internal/server/eventlog.go
@@ -78,13 +78,13 @@ type CallbackRequest struct {
 
 // WiringContext provides resolved endpoint information to callbacks.
 // All hooks and start callbacks receive the full wiring: Ingresses,
-// Egresses, TempDir, and EnvDir.
+// Egresses, TempDir, and EnvDir. Endpoints are resolved — all attribute
+// templates have been expanded to concrete values.
 type WiringContext struct {
-	Ingresses  map[string]spec.Endpoint `json:"ingresses,omitempty"`
-	Egresses   map[string]spec.Endpoint `json:"egresses,omitempty"`
-	TempDir    string                   `json:"temp_dir,omitempty"`
-	EnvDir     string                   `json:"env_dir,omitempty"`
-	Attributes map[string]string        `json:"attributes,omitempty"`
+	Ingresses map[string]spec.ResolvedEndpoint `json:"ingresses,omitempty"`
+	Egresses  map[string]spec.ResolvedEndpoint `json:"egresses,omitempty"`
+	TempDir   string                           `json:"temp_dir,omitempty"`
+	EnvDir    string                           `json:"env_dir,omitempty"`
 }
 
 // CallbackResponse is posted by the client after handling a callback request.
@@ -181,11 +181,9 @@ type Event struct {
 	EnvDir      string              `json:"env_dir,omitempty"`
 	Message     string              `json:"message,omitempty"`
 	// Ingresses is populated on environment.up. It maps service name to a
-	// map of ingress name to endpoint, giving clients everything they need
-	// to connect to any service without a follow-up GET request.
-	// It uses spec.Endpoint directly — the same type client libraries are
-	// built against — so test and production wiring are handled identically.
-	Ingresses map[string]map[string]spec.Endpoint `json:"ingresses,omitempty"`
+	// map of ingress name to resolved endpoint, giving clients everything
+	// they need to connect to any service without a follow-up GET request.
+	Ingresses map[string]map[string]spec.ResolvedEndpoint `json:"ingresses,omitempty"`
 	Timestamp time.Time                           `json:"timestamp"`
 }
 

--- a/internal/server/service/postgres.go
+++ b/internal/server/service/postgres.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strconv"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/matgreaves/rig/connect"
@@ -53,15 +52,11 @@ func (Postgres) Publish(_ context.Context, params PublishParams) (map[string]spe
 		if ep.Attributes == nil {
 			ep.Attributes = make(map[string]any)
 		}
-		connect.PGHost.Set(ep.Attributes, ep.Host)
-		connect.PGPort.Set(ep.Attributes, strconv.Itoa(ep.Port))
+		connect.PGHost.Set(ep.Attributes, "${HOST}")
+		connect.PGPort.Set(ep.Attributes, "${PORT}")
 		connect.PGDatabase.Set(ep.Attributes, params.ServiceName)
 		connect.PGUser.Set(ep.Attributes, postgresDefaultUser)
 		connect.PGPassword.Set(ep.Attributes, postgresDefaultPassword)
-		ep.AddressAttrs = map[string]spec.AddrAttr{
-			"PGHOST": spec.AttrHost,
-			"PGPORT": spec.AttrPort,
-		}
 		endpoints[name] = ep
 	}
 	return endpoints, nil

--- a/internal/server/service/postgres_test.go
+++ b/internal/server/service/postgres_test.go
@@ -29,17 +29,30 @@ func TestPostgresPublish_InjectsAttributes(t *testing.T) {
 			t.Errorf("missing attribute %s", attr)
 		}
 	}
-	if ep.Attributes["PGHOST"] != "127.0.0.1" {
-		t.Errorf("PGHOST = %v, want 127.0.0.1", ep.Attributes["PGHOST"])
+	// PGHOST and PGPORT are stored as templates.
+	if ep.Attributes["PGHOST"] != "${HOST}" {
+		t.Errorf("PGHOST = %v, want ${HOST}", ep.Attributes["PGHOST"])
 	}
-	if ep.Attributes["PGPORT"] != "54321" {
-		t.Errorf("PGPORT = %v, want 54321", ep.Attributes["PGPORT"])
+	if ep.Attributes["PGPORT"] != "${PORT}" {
+		t.Errorf("PGPORT = %v, want ${PORT}", ep.Attributes["PGPORT"])
 	}
 	if ep.Attributes["PGUSER"] != "postgres" {
 		t.Errorf("PGUSER = %v, want postgres", ep.Attributes["PGUSER"])
 	}
 	if ep.Attributes["PGPASSWORD"] != "postgres" {
 		t.Errorf("PGPASSWORD = %v, want postgres", ep.Attributes["PGPASSWORD"])
+	}
+
+	// Templates should resolve correctly against the endpoint.
+	resolved, err := spec.ResolveAttributes(ep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved["PGHOST"] != "127.0.0.1" {
+		t.Errorf("resolved PGHOST = %v, want 127.0.0.1", resolved["PGHOST"])
+	}
+	if resolved["PGPORT"] != "54321" {
+		t.Errorf("resolved PGPORT = %v, want 54321", resolved["PGPORT"])
 	}
 }
 

--- a/internal/server/service/temporal.go
+++ b/internal/server/service/temporal.go
@@ -52,11 +52,8 @@ func (Temporal) Publish(_ context.Context, params PublishParams) (map[string]spe
 		if ep.Attributes == nil {
 			ep.Attributes = make(map[string]any)
 		}
-		connect.TemporalAddress.Set(ep.Attributes, fmt.Sprintf("%s:%d", ep.Host, ep.Port))
+		connect.TemporalAddress.Set(ep.Attributes, "${HOSTPORT}")
 		connect.TemporalNamespace.Set(ep.Attributes, cfg.Namespace)
-		ep.AddressAttrs = map[string]spec.AddrAttr{
-			"TEMPORAL_ADDRESS": spec.AttrHostPort,
-		}
 		endpoints["default"] = ep
 	}
 	return endpoints, nil

--- a/internal/server/service/type.go
+++ b/internal/server/service/type.go
@@ -38,7 +38,7 @@ type StartParams struct {
 	// Service types that need to adjust endpoints for a different network
 	// namespace (e.g. containers) call this with modified endpoints instead
 	// of patching the flat Env map directly.
-	BuildEnv func(ingresses, egresses map[string]spec.Endpoint) map[string]string
+	BuildEnv func(ingresses, egresses map[string]spec.Endpoint) (map[string]string, error)
 
 	// Callback dispatches a callback request to the client SDK and blocks
 	// until the response arrives. Nil for types that don't use callbacks.

--- a/internal/spec/environment.go
+++ b/internal/spec/environment.go
@@ -25,8 +25,10 @@ type ResolvedEnvironment struct {
 }
 
 // ResolvedService is the runtime view of a single service.
+// Ingresses and egresses use ResolvedEndpoint — all attribute templates
+// have been expanded to concrete values.
 type ResolvedService struct {
-	Ingresses map[string]Endpoint `json:"ingresses"`
-	Egresses  map[string]Endpoint `json:"egresses"`
-	Status    ServiceStatus       `json:"status"`
+	Ingresses map[string]ResolvedEndpoint `json:"ingresses"`
+	Egresses  map[string]ResolvedEndpoint `json:"egresses"`
+	Status    ServiceStatus               `json:"status"`
 }


### PR DESCRIPTION
## Summary

- Endpoint attributes now store `${VAR}` templates (e.g. `PGHOST="${HOST}"`, `TEMPORAL_ADDRESS="${HOSTPORT}"`) instead of concrete values with separate `AddressAttrs` metadata
- Templates are resolved at output boundaries against three built-in variables: `HOST`, `PORT`, `HOSTPORT`
- Adds `ResolvedEndpoint` type for compile-time safety at output boundaries
- Eliminates `AddressAttrs`, `RewriteAddressAttrs`, and `adjustAttrs` entirely — container/proxy address adjustment is just changing `ep.Host`/`ep.Port`

## Test plan

- [x] `make test` passes (all modules: root, internal, examples)
- [x] Integration tests exercise real Postgres and Temporal with template wiring end-to-end
- [x] Unit tests cover: single-pass resolution, compound builtins (`${HOST}:${PORT}`), unknown var error, nil/empty attributes, proxy template passthrough, container adjustment passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)