### PR TITLE
Replace Host+Port with HostPort on endpoint types

### DIFF
--- a/agents-guide.md
+++ b/agents-guide.md
@@ -12,7 +12,7 @@ env := rig.Up(t, rig.Services{
     "temporal": rig.Temporal(),
     "api":      rig.Go("./cmd/api").Egress("db").Egress("temporal"),
 })
-ep := env.Endpoint("api") // connect.Endpoint{Host, Port, Protocol, Attributes}
+ep := env.Endpoint("api") // connect.Endpoint{HostPort, Protocol, Attributes}
 ```
 
 `rig.Up` blocks until all services are healthy and registers `t.Cleanup` for teardown. `rigd` is auto-downloaded on first use.
@@ -50,7 +50,7 @@ Services declare dependencies with `.Egress("service")`. Rig resolves the depend
 ```go
 w, _ := connect.ParseWiring(ctx)
 dbEp := w.Egress("db")       // connect.Endpoint
-addr := dbEp.Addr()           // "host:port"
+addr := dbEp.HostPort         // "host:port"
 dsn := connect.PostgresDSN(dbEp)
 ```
 

--- a/client/rig_test.go
+++ b/client/rig_test.go
@@ -12,31 +12,31 @@ func TestEndpoint_Lookup(t *testing.T) {
 		Name: "test",
 		Services: map[string]rig.ResolvedService{
 			"api": {Ingresses: map[string]rig.Endpoint{
-				"default": {Host: "127.0.0.1", Port: 8080, Protocol: rig.HTTP},
-				"grpc":    {Host: "127.0.0.1", Port: 9090, Protocol: rig.GRPC},
+				"default": {HostPort: "127.0.0.1:8080", Protocol: rig.HTTP},
+				"grpc":    {HostPort: "127.0.0.1:9090", Protocol: rig.GRPC},
 			}},
 			"db": {Ingresses: map[string]rig.Endpoint{
-				"tcp": {Host: "127.0.0.1", Port: 5432, Protocol: rig.TCP},
+				"tcp": {HostPort: "127.0.0.1:5432", Protocol: rig.TCP},
 			}},
 		},
 	}
 
 	// Default ingress by name.
 	ep := env.Endpoint("api")
-	if ep.Port != 8080 {
-		t.Errorf("api default port = %d, want 8080", ep.Port)
+	if ep.Port() != 8080 {
+		t.Errorf("api default port = %d, want 8080", ep.Port())
 	}
 
 	// Named ingress.
 	ep = env.Endpoint("api", "grpc")
-	if ep.Port != 9090 {
-		t.Errorf("api grpc port = %d, want 9090", ep.Port)
+	if ep.Port() != 9090 {
+		t.Errorf("api grpc port = %d, want 9090", ep.Port())
 	}
 
 	// Single ingress shorthand — returns sole ingress even if not named "default".
 	ep = env.Endpoint("db")
-	if ep.Port != 5432 {
-		t.Errorf("db port = %d, want 5432", ep.Port)
+	if ep.Port() != 5432 {
+		t.Errorf("db port = %d, want 5432", ep.Port())
 	}
 }
 
@@ -46,7 +46,7 @@ func TestEndpoint_Lookup_PanicsOnMiss(t *testing.T) {
 		Name: "test",
 		Services: map[string]rig.ResolvedService{
 			"api": {Ingresses: map[string]rig.Endpoint{
-				"default": {Host: "127.0.0.1", Port: 8080, Protocol: rig.HTTP},
+				"default": {HostPort: "127.0.0.1:8080", Protocol: rig.HTTP},
 			}},
 		},
 	}
@@ -62,29 +62,28 @@ func TestEndpoint_Lookup_PanicsOnMiss(t *testing.T) {
 	})
 }
 
-func TestEndpoint_ConnectionHelpers(t *testing.T) {
+func TestEndpoint_HostPort(t *testing.T) {
 	t.Parallel()
-	httpEP := rig.Endpoint{Host: "127.0.0.1", Port: 8080, Protocol: rig.HTTP}
-	if got := httpEP.Addr(); got != "127.0.0.1:8080" {
-		t.Errorf("HTTP Addr = %q, want 127.0.0.1:8080", got)
+	httpEP := rig.Endpoint{HostPort: "127.0.0.1:8080", Protocol: rig.HTTP}
+	if got := httpEP.HostPort; got != "127.0.0.1:8080" {
+		t.Errorf("HTTP HostPort = %q, want 127.0.0.1:8080", got)
 	}
 
-	grpcEP := rig.Endpoint{Host: "127.0.0.1", Port: 9090, Protocol: rig.GRPC}
-	if got := grpcEP.Addr(); got != "127.0.0.1:9090" {
-		t.Errorf("GRPC Addr = %q, want 127.0.0.1:9090", got)
+	grpcEP := rig.Endpoint{HostPort: "127.0.0.1:9090", Protocol: rig.GRPC}
+	if got := grpcEP.HostPort; got != "127.0.0.1:9090" {
+		t.Errorf("GRPC HostPort = %q, want 127.0.0.1:9090", got)
 	}
 
-	tcpEP := rig.Endpoint{Host: "127.0.0.1", Port: 5432, Protocol: rig.TCP}
-	if got := tcpEP.Addr(); got != "127.0.0.1:5432" {
-		t.Errorf("TCP Addr = %q, want 127.0.0.1:5432", got)
+	tcpEP := rig.Endpoint{HostPort: "127.0.0.1:5432", Protocol: rig.TCP}
+	if got := tcpEP.HostPort; got != "127.0.0.1:5432" {
+		t.Errorf("TCP HostPort = %q, want 127.0.0.1:5432", got)
 	}
 }
 
 func TestEndpoint_Attr(t *testing.T) {
 	t.Parallel()
 	ep := rig.Endpoint{
-		Host:     "127.0.0.1",
-		Port:     5432,
+		HostPort: "127.0.0.1:5432",
 		Protocol: rig.TCP,
 		Attributes: map[string]any{
 			"PGDATABASE": "testdb",

--- a/client/smoke_test.go
+++ b/client/smoke_test.go
@@ -28,7 +28,7 @@ func TestSmoke(t *testing.T) {
 		}),
 	}, rig.WithTimeout(30*time.Second))
 
-	resp, err := http.Get("http://" + env.Endpoint("echo").Addr() + "/")
+	resp, err := http.Get("http://" + env.Endpoint("echo").HostPort + "/")
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}

--- a/client/stream.go
+++ b/client/stream.go
@@ -70,8 +70,7 @@ type wireWiringContext struct {
 }
 
 type wireEndpoint struct {
-	Host       string         `json:"host"`
-	Port       int            `json:"port"`
+	HostPort   string         `json:"hostport"`
 	Protocol   Protocol       `json:"protocol"`
 	Attributes map[string]any `json:"attributes,omitempty"`
 }
@@ -352,8 +351,7 @@ func convertEndpoints(eps map[string]wireEndpoint) map[string]Endpoint {
 	out := make(map[string]Endpoint, len(eps))
 	for name, ep := range eps {
 		out[name] = Endpoint{
-			Host:       ep.Host,
-			Port:       ep.Port,
+			HostPort:   ep.HostPort,
 			Protocol:   ep.Protocol,
 			Attributes: ep.Attributes,
 		}
@@ -368,8 +366,7 @@ func buildEnvironmentFromEvent(ev wireEvent) *Environment {
 		ingresses := make(map[string]Endpoint, len(ingressMap))
 		for ingName, ep := range ingressMap {
 			ingresses[ingName] = Endpoint{
-				Host:       ep.Host,
-				Port:       ep.Port,
+				HostPort:   ep.HostPort,
 				Protocol:   ep.Protocol,
 				Attributes: ep.Attributes,
 			}

--- a/connect/endpoint.go
+++ b/connect/endpoint.go
@@ -5,7 +5,11 @@
 // without depending on the full rig SDK.
 package connect
 
-import "fmt"
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
 
 // Protocol identifies the application-layer protocol an endpoint speaks.
 type Protocol string
@@ -19,15 +23,22 @@ const (
 
 // Endpoint is a resolved service endpoint with connection helpers.
 type Endpoint struct {
-	Host       string         `json:"host"`
-	Port       int            `json:"port"`
+	HostPort   string         `json:"hostport"`
 	Protocol   Protocol       `json:"protocol"`
 	Attributes map[string]any `json:"attributes,omitempty"`
 }
 
-// Addr returns "host:port" suitable for net.Dial, grpc.Dial, etc.
-func (e Endpoint) Addr() string {
-	return fmt.Sprintf("%s:%d", e.Host, e.Port)
+// Host returns the host portion of HostPort.
+func (e Endpoint) Host() string {
+	host, _, _ := net.SplitHostPort(e.HostPort)
+	return host
+}
+
+// Port returns the port portion of HostPort as an int.
+func (e Endpoint) Port() int {
+	_, portStr, _ := net.SplitHostPort(e.HostPort)
+	port, _ := strconv.Atoi(portStr)
+	return port
 }
 
 // Attr returns the value of a named attribute as a string. Returns "" if

--- a/connect/httpx/client.go
+++ b/connect/httpx/client.go
@@ -31,7 +31,7 @@ type Client struct {
 
 // New creates an HTTP client from a resolved endpoint.
 func New(ep connect.Endpoint) *Client {
-	return &Client{BaseURL: "http://" + ep.Addr()}
+	return &Client{BaseURL: "http://" + ep.HostPort}
 }
 
 // NewClient creates an HTTP client for the given base URL string.

--- a/connect/httpx/server.go
+++ b/connect/httpx/server.go
@@ -34,7 +34,7 @@ func ListenAndServe(ctx context.Context, handler http.Handler) error {
 // with a 5-second timeout.
 func Serve(ctx context.Context, ep connect.Endpoint, handler http.Handler) error {
 	srv := &http.Server{
-		Addr:    ep.Addr(),
+		Addr:    ep.HostPort,
 		Handler: handler,
 	}
 

--- a/connect/pgx/pgx_test.go
+++ b/connect/pgx/pgx_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestDSN(t *testing.T) {
 	ep := connect.Endpoint{
-		Host:     "127.0.0.1",
-		Port:     5432,
+		HostPort: "127.0.0.1:5432",
 		Protocol: connect.TCP,
 		Attributes: map[string]any{
 			"PGHOST":     "127.0.0.1",
@@ -29,7 +28,7 @@ func TestDSN(t *testing.T) {
 }
 
 func TestDSN_Missing(t *testing.T) {
-	ep := connect.Endpoint{Host: "127.0.0.1", Port: 5432}
+	ep := connect.Endpoint{HostPort: "127.0.0.1:5432"}
 	want := "postgres://:@:/?sslmode=disable"
 	if got := rigpgx.DSN(ep); got != want {
 		t.Errorf("DSN = %q, want %q", got, want)

--- a/connect/temporalx/temporalx_test.go
+++ b/connect/temporalx/temporalx_test.go
@@ -12,8 +12,7 @@ import (
 
 func TestAddr(t *testing.T) {
 	ep := connect.Endpoint{
-		Host:     "127.0.0.1",
-		Port:     7233,
+		HostPort: "127.0.0.1:7233",
 		Protocol: connect.GRPC,
 		Attributes: map[string]any{
 			"TEMPORAL_ADDRESS":   "127.0.0.1:7233",
@@ -26,7 +25,7 @@ func TestAddr(t *testing.T) {
 }
 
 func TestAddr_Missing(t *testing.T) {
-	ep := connect.Endpoint{Host: "127.0.0.1", Port: 7233}
+	ep := connect.Endpoint{HostPort: "127.0.0.1:7233"}
 	if got := temporalx.Addr(ep); got != "" {
 		t.Errorf("Addr = %q, want empty", got)
 	}
@@ -34,8 +33,7 @@ func TestAddr_Missing(t *testing.T) {
 
 func TestNamespace(t *testing.T) {
 	ep := connect.Endpoint{
-		Host:     "127.0.0.1",
-		Port:     7233,
+		HostPort: "127.0.0.1:7233",
 		Protocol: connect.GRPC,
 		Attributes: map[string]any{
 			"TEMPORAL_ADDRESS":   "127.0.0.1:7233",
@@ -48,7 +46,7 @@ func TestNamespace(t *testing.T) {
 }
 
 func TestNamespace_Missing(t *testing.T) {
-	ep := connect.Endpoint{Host: "127.0.0.1", Port: 7233}
+	ep := connect.Endpoint{HostPort: "127.0.0.1:7233"}
 	if got := temporalx.Namespace(ep); got != "" {
 		t.Errorf("Namespace = %q, want empty", got)
 	}

--- a/connect/wiring.go
+++ b/connect/wiring.go
@@ -73,13 +73,12 @@ func ParseWiring(ctx context.Context) (*Wiring, error) {
 	if host == "" || portStr == "" {
 		return nil, fmt.Errorf("HOST and PORT must be set (or RIG_WIRING)")
 	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
+	if _, err := strconv.Atoi(portStr); err != nil {
 		return nil, fmt.Errorf("invalid PORT %q: %w", portStr, err)
 	}
 	return &Wiring{
 		Ingresses: map[string]Endpoint{
-			"default": {Host: host, Port: port},
+			"default": {HostPort: host + ":" + portStr},
 		},
 	}, nil
 }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -61,10 +61,10 @@ Returns the current resolved state of the environment.
   "services": {
     "api": {
       "ingresses": {
-        "default": {"host": "127.0.0.1", "port": 54321, "protocol": "http", "attributes": {}}
+        "default": {"hostport": "127.0.0.1:54321", "protocol": "http", "attributes": {}}
       },
       "egresses": {
-        "db": {"host": "127.0.0.1", "port": 54322, "protocol": "tcp", "attributes": {...}}
+        "db": {"hostport": "127.0.0.1:54322", "protocol": "tcp", "attributes": {...}}
       },
       "status": "ready"
     }
@@ -263,8 +263,7 @@ Resolved at runtime by the server. Never appears in the spec — only in events 
 
 ```json
 {
-  "host": "127.0.0.1",
-  "port": 54321,
+  "hostport": "127.0.0.1:54321",
   "protocol": "tcp",
   "attributes": {
     "PGHOST": "127.0.0.1",
@@ -278,8 +277,7 @@ Resolved at runtime by the server. Never appears in the spec — only in events 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `host` | string | Hostname or IP |
-| `port` | integer | Port number |
+| `hostport` | string | Host and port as `"host:port"` |
 | `protocol` | string | `"tcp"`, `"http"`, `"grpc"`, `"kafka"` |
 | `attributes` | object | Key-value attributes (typed as `any` — strings, numbers, booleans). Attributes sent to clients are fully resolved; internally attributes may contain `${VAR}` template references. |
 
@@ -289,9 +287,9 @@ Service type implementations store attribute values as templates referencing bui
 
 | Variable | Source | Example value |
 |----------|--------|---------------|
-| `HOST` | `ep.Host` | `127.0.0.1` |
-| `PORT` | `ep.Port` | `5432` |
-| `HOSTPORT` | `ep.Host:ep.Port` | `127.0.0.1:5432` |
+| `HOST` | `ep.Host()` | `127.0.0.1` |
+| `PORT` | `ep.Port()` | `5432` |
+| `HOSTPORT` | `ep.HostPort` | `127.0.0.1:5432` |
 
 Only these three built-in variables are available. Templates use `${VAR}` syntax and are resolved in a single pass. Referencing an unknown variable is an error.
 
@@ -419,8 +417,8 @@ The callback protocol enables client-side code execution (hooks and Func service
     "name": "seed_data",
     "type": "hook",
     "wiring": {
-      "ingresses": {"default": {"host": "127.0.0.1", "port": 54321, "protocol": "http"}},
-      "egresses": {"db": {"host": "127.0.0.1", "port": 54322, "protocol": "tcp", "attributes": {...}}},
+      "ingresses": {"default": {"hostport": "127.0.0.1:54321", "protocol": "http"}},
+      "egresses": {"db": {"hostport": "127.0.0.1:54322", "protocol": "tcp", "attributes": {...}}},
       "temp_dir": "/tmp/rig/a1b2c3/api",
       "env_dir": "/tmp/rig/a1b2c3"
     }

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -108,7 +108,7 @@ Runs a function in the test process as a service.
 ```go
 rig.Func(func(ctx context.Context) error {
     w, _ := connect.ParseWiring(ctx)
-    return http.ListenAndServe(fmt.Sprintf(":%d", w.Ingress().Port), handler)
+    return http.ListenAndServe(w.Ingress().HostPort, handler)
 })
 ```
 

--- a/examples/orderflow/run.go
+++ b/examples/orderflow/run.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context) error {
 	}
 	defer tc.Close()
 
-	logger.Info("connected", "db", w.Egress("db").Addr(), "temporal", w.Egress("temporal").Addr())
+	logger.Info("connected", "db", w.Egress("db").HostPort, "temporal", w.Egress("temporal").HostPort)
 
 	// Start Temporal worker — inherits the client's logger.
 	wkr := worker.New(tc, "orders", worker.Options{})

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -176,7 +176,7 @@ func TestUp(t *testing.T) {
 		}
 
 		// DB should be reachable via TCP.
-		conn, err := net.DialTimeout("tcp", env.Endpoint("db").Addr(), 2*time.Second)
+		conn, err := net.DialTimeout("tcp", env.Endpoint("db").HostPort, 2*time.Second)
 		if err != nil {
 			t.Fatalf("db dial: %v", err)
 		}
@@ -308,7 +308,7 @@ func TestUp(t *testing.T) {
 		}
 
 		// DB should be reachable via TCP.
-		conn, err := net.DialTimeout("tcp", env.Endpoint("db").Addr(), 2*time.Second)
+		conn, err := net.DialTimeout("tcp", env.Endpoint("db").HostPort, 2*time.Second)
 		if err != nil {
 			t.Fatalf("db dial: %v", err)
 		}
@@ -351,7 +351,7 @@ func TestUp(t *testing.T) {
 		}, rig.WithServer(serverURL), rig.WithTimeout(60*time.Second))
 
 		ep := env.Endpoint("nginx")
-		resp, err := http.Get("http://" + ep.Addr() + "/")
+		resp, err := http.Get("http://" + ep.HostPort + "/")
 		if err != nil {
 			t.Fatalf("nginx request: %v", err)
 		}
@@ -371,7 +371,7 @@ func TestUp(t *testing.T) {
 		ep := env.Endpoint("db")
 
 		// Verify TCP connectivity.
-		conn, err := net.DialTimeout("tcp", ep.Addr(), 5*time.Second)
+		conn, err := net.DialTimeout("tcp", ep.HostPort, 5*time.Second)
 		if err != nil {
 			t.Fatalf("postgres dial: %v", err)
 		}
@@ -404,7 +404,7 @@ func TestUp(t *testing.T) {
 
 		// gRPC port reachable.
 		ep := env.Endpoint("temporal")
-		conn, err := net.DialTimeout("tcp", ep.Addr(), 5*time.Second)
+		conn, err := net.DialTimeout("tcp", ep.HostPort, 5*time.Second)
 		if err != nil {
 			t.Fatalf("temporal dial: %v", err)
 		}
@@ -420,7 +420,7 @@ func TestUp(t *testing.T) {
 
 		// UI reachable.
 		uiEP := env.Endpoint("temporal", "ui")
-		resp, err := http.Get("http://" + uiEP.Addr())
+		resp, err := http.Get("http://" + uiEP.HostPort)
 		if err != nil {
 			t.Fatalf("temporal UI request: %v", err)
 		}
@@ -469,7 +469,7 @@ func TestUp(t *testing.T) {
 
 		// Verify service is reachable.
 		ep := env.Endpoint("db")
-		conn, err := net.DialTimeout("tcp", ep.Addr(), 5*time.Second)
+		conn, err := net.DialTimeout("tcp", ep.HostPort, 5*time.Second)
 		if err != nil {
 			t.Fatalf("postgres dial: %v", err)
 		}
@@ -839,7 +839,7 @@ func TestObserveAttributes(t *testing.T) {
 	ep := env.Endpoint("temporal")
 
 	// TEMPORAL_ADDRESS must match the proxy endpoint, not the real service.
-	wantAddr := fmt.Sprintf("127.0.0.1:%d", ep.Port)
+	wantAddr := fmt.Sprintf("127.0.0.1:%d", ep.Port())
 	if got := ep.Attr("TEMPORAL_ADDRESS"); got != wantAddr {
 		t.Errorf("TEMPORAL_ADDRESS = %q, want %q (proxy address)", got, wantAddr)
 	}
@@ -850,7 +850,7 @@ func TestObserveAttributes(t *testing.T) {
 	}
 
 	// Verify TCP connectivity through the proxy.
-	conn, err := net.DialTimeout("tcp", ep.Addr(), 5*time.Second)
+	conn, err := net.DialTimeout("tcp", ep.HostPort, 5*time.Second)
 	if err != nil {
 		t.Fatalf("temporal dial through proxy: %v", err)
 	}
@@ -870,7 +870,7 @@ func TestObserveTCP(t *testing.T) {
 
 	// Connect through the proxy.
 	ep := env.Endpoint("tcpecho")
-	conn, err := net.DialTimeout("tcp", ep.Addr(), 2*time.Second)
+	conn, err := net.DialTimeout("tcp", ep.HostPort, 2*time.Second)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -939,7 +939,7 @@ func TestObserveGRPC(t *testing.T) {
 
 	// Make a gRPC health check call through the proxy endpoint.
 	ep := env.Endpoint("temporal")
-	conn, err := grpc.NewClient(ep.Addr(),
+	conn, err := grpc.NewClient(ep.HostPort,
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("grpc dial: %v", err)
@@ -1037,7 +1037,7 @@ func TestFuncLogWriter(t *testing.T) {
 	}, rig.WithServer(serverURL), rig.WithTimeout(30*time.Second))
 
 	// Hit the service to confirm it's up.
-	resp, err := http.Get("http://" + env.Endpoint("logger").Addr() + "/")
+	resp, err := http.Get("http://" + env.Endpoint("logger").HostPort + "/")
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}

--- a/internal/server/lifecycle.go
+++ b/internal/server/lifecycle.go
@@ -328,7 +328,7 @@ func readyCheckRunner(sc *serviceContext) run.Runner {
 					Error:       err.Error(),
 				})
 			}
-			if err := ready.Poll(ctx, ep.Host, ep.Port, checker, readySpec, onFailure); err != nil {
+			if err := ready.Poll(ctx, ep.HostPort, checker, readySpec, onFailure); err != nil {
 				return fmt.Errorf("ingress %q: %w", ingressName, err)
 			}
 		}

--- a/internal/server/proxy/forwarder_test.go
+++ b/internal/server/proxy/forwarder_test.go
@@ -9,10 +9,9 @@ import (
 
 func TestForwarderEndpoint_TemplateAttrsPassThrough(t *testing.T) {
 	f := &proxy.Forwarder{
-		ListenPort: 9999,
+		ListenAddr: "127.0.0.1:9999",
 		Target: spec.Endpoint{
-			Host:     "10.0.0.5",
-			Port:     5432,
+			HostPort: "10.0.0.5:5432",
 			Protocol: spec.TCP,
 			Attributes: map[string]any{
 				"PGHOST":     "${HOST}",
@@ -24,18 +23,15 @@ func TestForwarderEndpoint_TemplateAttrsPassThrough(t *testing.T) {
 
 	ep := f.Endpoint()
 
-	if ep.Host != "127.0.0.1" {
-		t.Errorf("Host = %q, want 127.0.0.1", ep.Host)
-	}
-	if ep.Port != 9999 {
-		t.Errorf("Port = %d, want 9999", ep.Port)
+	if ep.HostPort != "127.0.0.1:9999" {
+		t.Errorf("HostPort = %q, want 127.0.0.1:9999", ep.HostPort)
 	}
 	if ep.Protocol != spec.TCP {
 		t.Errorf("Protocol = %q, want tcp", ep.Protocol)
 	}
 
 	// Template attributes should be copied unchanged — they resolve
-	// against the proxy's Host/Port when consumed downstream.
+	// against the proxy's HostPort when consumed downstream.
 	if got := ep.Attributes["PGHOST"]; got != "${HOST}" {
 		t.Errorf("PGHOST = %v, want ${HOST}", got)
 	}
@@ -51,10 +47,9 @@ func TestForwarderEndpoint_TemplateAttrsPassThrough(t *testing.T) {
 
 func TestForwarderEndpoint_HostPort(t *testing.T) {
 	f := &proxy.Forwarder{
-		ListenPort: 7233,
+		ListenAddr: "127.0.0.1:7233",
 		Target: spec.Endpoint{
-			Host:     "10.0.0.5",
-			Port:     7233,
+			HostPort: "10.0.0.5:7233",
 			Protocol: spec.GRPC,
 			Attributes: map[string]any{
 				"TEMPORAL_ADDRESS":   "${HOSTPORT}",
@@ -86,10 +81,9 @@ func TestForwarderEndpoint_HostPort(t *testing.T) {
 
 func TestForwarderEndpoint_NoAttributes(t *testing.T) {
 	f := &proxy.Forwarder{
-		ListenPort: 8080,
+		ListenAddr: "127.0.0.1:8080",
 		Target: spec.Endpoint{
-			Host:     "10.0.0.5",
-			Port:     8080,
+			HostPort: "10.0.0.5:8080",
 			Protocol: spec.HTTP,
 			Attributes: map[string]any{
 				"FOO": "bar",
@@ -107,10 +101,9 @@ func TestForwarderEndpoint_NoAttributes(t *testing.T) {
 
 func TestForwarderEndpoint_NilAttributes(t *testing.T) {
 	f := &proxy.Forwarder{
-		ListenPort: 8080,
+		ListenAddr: "127.0.0.1:8080",
 		Target: spec.Endpoint{
-			Host:     "10.0.0.5",
-			Port:     8080,
+			HostPort: "10.0.0.5:8080",
 			Protocol: spec.HTTP,
 		},
 	}

--- a/internal/server/proxy/grpc.go
+++ b/internal/server/proxy/grpc.go
@@ -18,7 +18,7 @@ import (
 func (f *Forwarder) runGRPC(ctx context.Context) error {
 	target := &url.URL{
 		Scheme: "http",
-		Host:   f.targetAddr(),
+		Host:   f.Target.HostPort,
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(target)

--- a/internal/server/proxy/http.go
+++ b/internal/server/proxy/http.go
@@ -24,7 +24,7 @@ const maxBodyCapture = 64 * 1024 // 64KB
 func (f *Forwarder) runHTTP(ctx context.Context) error {
 	target := &url.URL{
 		Scheme: "http",
-		Host:   f.targetAddr(),
+		Host:   f.Target.HostPort,
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(target)

--- a/internal/server/proxy/kafka_test.go
+++ b/internal/server/proxy/kafka_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -820,8 +821,8 @@ func TestKafkaProxy_EndToEnd(t *testing.T) {
 	var eventMu sync.Mutex
 
 	f := &Forwarder{
-		ListenPort: proxyAddr.Port,
-		Target: spec.Endpoint{Host: "127.0.0.1", Port: brokerAddr.Port, Protocol: spec.Kafka},
+		ListenAddr: proxyAddr.String(),
+		Target:     spec.Endpoint{HostPort: fmt.Sprintf("127.0.0.1:%d", brokerAddr.Port), Protocol: spec.Kafka},
 		Source:     "test-client",
 		TargetSvc:  "kafka",
 		Ingress:    "default",

--- a/internal/server/proxy/proxy_bench_test.go
+++ b/internal/server/proxy/proxy_bench_test.go
@@ -64,10 +64,9 @@ func BenchmarkHTTPProxied(b *testing.B) {
 
 	// Create and start the forwarder.
 	fwd := &proxy.Forwarder{
-		ListenPort: proxyPort,
+		ListenAddr: fmt.Sprintf("127.0.0.1:%d", proxyPort),
 		Target: spec.Endpoint{
-			Host:     backendHost,
-			Port:     backendPort,
+			HostPort: fmt.Sprintf("%s:%d", backendHost, backendPort),
 			Protocol: "http",
 		},
 		Source:    "external",

--- a/internal/server/proxy/tcp.go
+++ b/internal/server/proxy/tcp.go
@@ -46,7 +46,7 @@ func (f *Forwarder) handleTCPConn(ctx context.Context, client net.Conn) {
 		},
 	})
 
-	target, err := net.DialTimeout("tcp", f.targetAddr(), 5*time.Second)
+	target, err := net.DialTimeout("tcp", f.Target.HostPort, 5*time.Second)
 	if err != nil {
 		client.Close()
 		f.Emit(Event{

--- a/internal/server/ready/grpc.go
+++ b/internal/server/ready/grpc.go
@@ -16,8 +16,7 @@ import (
 // the check succeeds — a responding gRPC server is considered ready.
 type GRPC struct{}
 
-func (GRPC) Check(ctx context.Context, host string, port int) error {
-	addr := fmt.Sprintf("%s:%d", host, port)
+func (GRPC) Check(ctx context.Context, addr string) error {
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err

--- a/internal/server/ready/http.go
+++ b/internal/server/ready/http.go
@@ -13,13 +13,13 @@ type HTTP struct {
 	Path string // default "/"
 }
 
-func (h *HTTP) Check(ctx context.Context, host string, port int) error {
+func (h *HTTP) Check(ctx context.Context, addr string) error {
 	path := h.Path
 	if path == "" {
 		path = "/"
 	}
 
-	url := fmt.Sprintf("http://%s:%d%s", host, port, path)
+	url := fmt.Sprintf("http://%s%s", addr, path)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err

--- a/internal/server/ready/ready.go
+++ b/internal/server/ready/ready.go
@@ -21,7 +21,7 @@ const (
 
 // Checker performs a single readiness probe against an endpoint.
 type Checker interface {
-	Check(ctx context.Context, host string, port int) error
+	Check(ctx context.Context, addr string) error
 }
 
 // ForEndpoint returns a Checker appropriate for the given endpoint,
@@ -51,7 +51,7 @@ func ForEndpoint(ep spec.Endpoint, readySpec *spec.ReadySpec) Checker {
 //
 // If onFailure is non-nil it is called after each failed probe with the
 // check error, giving the caller an opportunity to log or emit events.
-func Poll(ctx context.Context, host string, port int, checker Checker, readySpec *spec.ReadySpec, onFailure func(err error)) error {
+func Poll(ctx context.Context, addr string, checker Checker, readySpec *spec.ReadySpec, onFailure func(err error)) error {
 	timeout := DefaultTimeout
 	interval := DefaultInitialInterval
 
@@ -70,7 +70,7 @@ func Poll(ctx context.Context, host string, port int, checker Checker, readySpec
 	var lastErr error
 
 	for {
-		if err := checker.Check(ctx, host, port); err == nil {
+		if err := checker.Check(ctx, addr); err == nil {
 			return nil
 		} else {
 			lastErr = err

--- a/internal/server/ready/tcp.go
+++ b/internal/server/ready/tcp.go
@@ -2,7 +2,6 @@ package ready
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"time"
 )
@@ -10,8 +9,7 @@ import (
 // TCP checks readiness by dialing a TCP connection.
 type TCP struct{}
 
-func (TCP) Check(ctx context.Context, host string, port int) error {
-	addr := fmt.Sprintf("%s:%d", host, port)
+func (TCP) Check(ctx context.Context, addr string) error {
 	d := net.Dialer{Timeout: 200 * time.Millisecond}
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -293,7 +293,7 @@ func TestServer(t *testing.T) {
 			t.Errorf("echo status = %q, want %q", echoSvc.Status, spec.StatusReady)
 		}
 		ep, ok := echoSvc.Ingresses["default"]
-		if !ok || ep.Port == 0 {
+		if !ok || ep.HostPort == "" {
 			t.Fatal("'default' ingress not resolved in GET response")
 		}
 

--- a/internal/server/service/postgres.go
+++ b/internal/server/service/postgres.go
@@ -79,7 +79,7 @@ type pgReadyCheck struct {
 	dbName        string
 }
 
-func (c *pgReadyCheck) Check(ctx context.Context, host string, port int) error {
+func (c *pgReadyCheck) Check(ctx context.Context, addr string) error {
 	cli, err := dockerutil.Client()
 	if err != nil {
 		return fmt.Errorf("pg_isready: docker client: %w", err)

--- a/internal/server/service/process_test.go
+++ b/internal/server/service/process_test.go
@@ -25,11 +25,8 @@ func TestProcessPublish_SingleIngress(t *testing.T) {
 	if !ok {
 		t.Fatal("missing default endpoint")
 	}
-	if ep.Host != "127.0.0.1" {
-		t.Errorf("host = %q, want 127.0.0.1", ep.Host)
-	}
-	if ep.Port != 8080 {
-		t.Errorf("port = %d, want 8080", ep.Port)
+	if ep.HostPort != "127.0.0.1:8080" {
+		t.Errorf("hostport = %q, want 127.0.0.1:8080", ep.HostPort)
 	}
 	if ep.Protocol != spec.HTTP {
 		t.Errorf("protocol = %q, want http", ep.Protocol)
@@ -53,11 +50,11 @@ func TestProcessPublish_MultipleIngresses(t *testing.T) {
 	if len(endpoints) != 2 {
 		t.Fatalf("expected 2 endpoints, got %d", len(endpoints))
 	}
-	if endpoints["http"].Port != 8080 {
-		t.Errorf("http port = %d, want 8080", endpoints["http"].Port)
+	if endpoints["http"].HostPort != "127.0.0.1:8080" {
+		t.Errorf("http hostport = %q, want 127.0.0.1:8080", endpoints["http"].HostPort)
 	}
-	if endpoints["grpc"].Port != 9090 {
-		t.Errorf("grpc port = %d, want 9090", endpoints["grpc"].Port)
+	if endpoints["grpc"].HostPort != "127.0.0.1:9090" {
+		t.Errorf("grpc hostport = %q, want 127.0.0.1:9090", endpoints["grpc"].HostPort)
 	}
 }
 

--- a/internal/server/service/proxy.go
+++ b/internal/server/service/proxy.go
@@ -81,8 +81,7 @@ func (p *Proxy) Publish(_ context.Context, params PublishParams) (map[string]spe
 
 	return map[string]spec.Endpoint{
 		"default": {
-			Host:       "127.0.0.1",
-			Port:       port,
+			HostPort:   fmt.Sprintf("127.0.0.1:%d", port),
 			Protocol:   target.Protocol,
 			Attributes: attrs,
 		},
@@ -109,7 +108,7 @@ func (p *Proxy) Runner(params StartParams) run.Runner {
 		}
 
 		fwd := &proxy.Forwarder{
-			ListenPort: ingress.Port,
+			ListenAddr: ingress.HostPort,
 			Target:     target,
 			Source:     cfg.Source,
 			TargetSvc:  cfg.TargetSvc,
@@ -126,8 +125,7 @@ func (p *Proxy) Runner(params StartParams) run.Runner {
 			if dec := p.cachedReflection(cfg.ReflectionKey); dec != nil {
 				fwd.Decoder = dec
 			} else {
-				addr := fmt.Sprintf("%s:%d", target.Host, target.Port)
-				dec = proxy.ProbeReflection(ctx, addr)
+				dec = proxy.ProbeReflection(ctx, target.HostPort)
 				fwd.Decoder = dec
 				p.cacheReflection(cfg.ReflectionKey, dec)
 			}

--- a/internal/server/service/temporal.go
+++ b/internal/server/service/temporal.go
@@ -77,10 +77,10 @@ func (Temporal) Runner(params StartParams) run.Runner {
 	grpcPort := 0
 	uiPort := 0
 	if ep, ok := params.Ingresses["default"]; ok {
-		grpcPort = ep.Port
+		grpcPort = ep.Port()
 	}
 	if ep, ok := params.Ingresses["ui"]; ok {
-		uiPort = ep.Port
+		uiPort = ep.Port()
 	}
 
 	args := []string{

--- a/internal/server/service/type.go
+++ b/internal/server/service/type.go
@@ -154,8 +154,7 @@ func PublishLocalEndpoints(params PublishParams) (map[string]spec.Endpoint, erro
 			return nil, fmt.Errorf("no port allocated for ingress %q", name)
 		}
 		endpoints[name] = spec.Endpoint{
-			Host:       "127.0.0.1",
-			Port:       port,
+			HostPort:   fmt.Sprintf("127.0.0.1:%d", port),
 			Protocol:   ingSpec.Protocol,
 			Attributes: ingSpec.Attributes,
 		}

--- a/internal/server/wiring.go
+++ b/internal/server/wiring.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -140,8 +141,9 @@ func addEndpointAttrs(env map[string]string, prefix string, ep spec.ResolvedEndp
 		}
 	}
 
-	set("HOST", ep.Host)
-	set("PORT", fmt.Sprintf("%d", ep.Port))
+	host, portStr, _ := net.SplitHostPort(ep.HostPort)
+	set("HOST", host)
+	set("PORT", portStr)
 
 	for k, v := range ep.Attributes {
 		set(k, fmt.Sprintf("%v", v))

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -30,8 +30,7 @@ func TestProtocolValid(t *testing.T) {
 
 func TestEndpointRoundTrip(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "127.0.0.1",
-		Port:     5432,
+		HostPort: "127.0.0.1:5432",
 		Protocol: spec.TCP,
 		Attributes: map[string]any{
 			"PGHOST":     "127.0.0.1",
@@ -50,7 +49,7 @@ func TestEndpointRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got.Host != ep.Host || got.Port != ep.Port || got.Protocol != ep.Protocol {
+	if got.HostPort != ep.HostPort || got.Protocol != ep.Protocol {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", got, ep)
 	}
 	if got.Attributes["PGDATABASE"] != "testdb" {
@@ -60,8 +59,7 @@ func TestEndpointRoundTrip(t *testing.T) {
 
 func TestEndpointOmitsEmptyAttributes(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "127.0.0.1",
-		Port:     8080,
+		HostPort: "127.0.0.1:8080",
 		Protocol: spec.HTTP,
 	}
 
@@ -316,15 +314,13 @@ func TestResolvedEnvironmentRoundTrip(t *testing.T) {
 			"my-api": {
 				Ingresses: map[string]spec.ResolvedEndpoint{
 					"default": {
-						Host:     "127.0.0.1",
-						Port:     8080,
+						HostPort: "127.0.0.1:8080",
 						Protocol: spec.HTTP,
 					},
 				},
 				Egresses: map[string]spec.ResolvedEndpoint{
 					"database": {
-						Host:     "127.0.0.1",
-						Port:     54321,
+						HostPort: "127.0.0.1:54321",
 						Protocol: spec.TCP,
 						Attributes: map[string]any{
 							"PGDATABASE": "testdb",
@@ -354,8 +350,8 @@ func TestResolvedEnvironmentRoundTrip(t *testing.T) {
 	if svc.Status != spec.StatusReady {
 		t.Errorf("status: got %q", svc.Status)
 	}
-	if svc.Ingresses["default"].Port != 8080 {
-		t.Errorf("ingress port: got %d", svc.Ingresses["default"].Port)
+	if svc.Ingresses["default"].Port() != 8080 {
+		t.Errorf("ingress port: got %d", svc.Ingresses["default"].Port())
 	}
 	if svc.Egresses["database"].Attributes["PGDATABASE"] != "testdb" {
 		t.Error("egress attributes lost in round-trip")
@@ -364,8 +360,7 @@ func TestResolvedEnvironmentRoundTrip(t *testing.T) {
 
 func TestResolveAttributes_Basic(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "10.0.0.1",
-		Port:     5432,
+		HostPort: "10.0.0.1:5432",
 		Protocol: spec.TCP,
 		Attributes: map[string]any{
 			"PGHOST":     "${HOST}",
@@ -396,8 +391,7 @@ func TestResolveAttributes_Basic(t *testing.T) {
 
 func TestResolveAttributes_CompoundBuiltins(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "10.0.0.1",
-		Port:     5432,
+		HostPort: "10.0.0.1:5432",
 		Protocol: spec.TCP,
 		Attributes: map[string]any{
 			"PGHOST":       "${HOST}",
@@ -421,8 +415,7 @@ func TestResolveAttributes_CompoundBuiltins(t *testing.T) {
 
 func TestResolveAttributes_NonBuiltinReturnsError(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "10.0.0.1",
-		Port:     5432,
+		HostPort: "10.0.0.1:5432",
 		Protocol: spec.TCP,
 		Attributes: map[string]any{
 			"PGHOST":       "${HOST}",
@@ -440,8 +433,7 @@ func TestResolveAttributes_NonBuiltinReturnsError(t *testing.T) {
 
 func TestResolveAttributes_NilAttributes(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "10.0.0.1",
-		Port:     5432,
+		HostPort: "10.0.0.1:5432",
 		Protocol: spec.TCP,
 	}
 	got, err := spec.ResolveAttributes(ep)
@@ -455,8 +447,7 @@ func TestResolveAttributes_NilAttributes(t *testing.T) {
 
 func TestResolveAttributes_EmptyAttributes(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:       "10.0.0.1",
-		Port:       5432,
+		HostPort:   "10.0.0.1:5432",
 		Protocol:   spec.TCP,
 		Attributes: map[string]any{},
 	}
@@ -471,8 +462,7 @@ func TestResolveAttributes_EmptyAttributes(t *testing.T) {
 
 func TestResolveAttributes_NoTemplates(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "10.0.0.1",
-		Port:     5432,
+		HostPort: "10.0.0.1:5432",
 		Protocol: spec.TCP,
 		Attributes: map[string]any{
 			"PGDATABASE": "mydb",
@@ -493,8 +483,7 @@ func TestResolveAttributes_NoTemplates(t *testing.T) {
 
 func TestResolveAttributes_DoesNotMutateSource(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "10.0.0.1",
-		Port:     5432,
+		HostPort: "10.0.0.1:5432",
 		Protocol: spec.TCP,
 		Attributes: map[string]any{
 			"PGHOST": "${HOST}",
@@ -510,8 +499,7 @@ func TestResolveAttributes_DoesNotMutateSource(t *testing.T) {
 
 func TestResolveAttributes_UnknownVarReturnsError(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "10.0.0.1",
-		Port:     5432,
+		HostPort: "10.0.0.1:5432",
 		Protocol: spec.TCP,
 		Attributes: map[string]any{
 			"ADDR": "${HOOST}/foo",
@@ -528,8 +516,7 @@ func TestResolveAttributes_UnknownVarReturnsError(t *testing.T) {
 
 func TestResolveAttributes_NonStringValue(t *testing.T) {
 	ep := spec.Endpoint{
-		Host:     "10.0.0.1",
-		Port:     5432,
+		HostPort: "10.0.0.1:5432",
 		Protocol: spec.TCP,
 		Attributes: map[string]any{
 			"MAX_CONNS": 100,

--- a/internal/testdata/services/tcpecho/main.go
+++ b/internal/testdata/services/tcpecho/main.go
@@ -28,12 +28,12 @@ func run(ctx context.Context) error {
 	}
 	ep := w.Ingress()
 
-	ln, err := net.Listen("tcp", ep.Addr())
+	ln, err := net.Listen("tcp", ep.HostPort)
 	if err != nil {
 		return fmt.Errorf("listen: %w", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "tcpecho: listening on %s\n", ep.Addr())
+	fmt.Fprintf(os.Stdout, "tcpecho: listening on %s\n", ep.HostPort)
 
 	go func() {
 		<-ctx.Done()

--- a/internal/testdata/services/userapi/main.go
+++ b/internal/testdata/services/userapi/main.go
@@ -34,7 +34,7 @@ func run(ctx context.Context) error {
 
 	pg := w.Egress("db")
 	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-		pg.Host, pg.Port, pg.Attr("PGUSER"), pg.Attr("PGPASSWORD"), pg.Attr("PGDATABASE"))
+		pg.Host(), pg.Port(), pg.Attr("PGUSER"), pg.Attr("PGPASSWORD"), pg.Attr("PGDATABASE"))
 
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Replaces `Host string` + `Port int` with a single `HostPort string` field on all endpoint types (`connect.Endpoint`, `spec.Endpoint`, `spec.ResolvedEndpoint`)
- Removes `Addr()` method — `HostPort` IS the address
- Adds `Host()` and `Port()` getter methods for the few call sites that need the components split
- Wire format changes from `{"host":"...","port":N}` to `{"hostport":"host:port"}`
- Simplifies ready check interface: `Check(ctx, addr)` instead of `Check(ctx, host, port)`
- Simplifies proxy forwarder: `ListenAddr string` instead of `ListenPort int`

42 files changed, 255 insertions, 276 deletions.

## Test plan

- [x] `make test` passes across all 5 Go modules (root, internal, connect/temporalx, connect/pgx, examples)
- [x] Integration tests pass (cleared stale artifact cache to force recompilation against new types)
- [x] Wire format deserialization verified via `client/smoke_test.go`
- [x] Ready checks (TCP, HTTP, gRPC) verified with updated signatures
- [x] Proxy forwarder tests pass with `ListenAddr` change
- [x] Docs (`protocol.md`, `sdk.md`, `agents-guide.md`) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)